### PR TITLE
Reusable Alert Modal

### DIFF
--- a/src/components/Modal/AlertModal.styles.ts
+++ b/src/components/Modal/AlertModal.styles.ts
@@ -1,0 +1,37 @@
+import { StyleSheet } from 'react-native';
+import { Theme } from '../../utils/themes';
+
+export const getStyles = (theme: Theme) => StyleSheet.create({
+    overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.4)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  modalContainer: {
+    backgroundColor: 'white',
+    borderRadius: 10,
+    padding: 25,
+    width: '80%',
+    elevation: 5,
+  },
+message: {
+    fontSize: 16,
+    fontWeight:'bold',
+    textAlign: 'center',
+    marginBottom: 25,
+    color:'#008080',
+  },
+buttonContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+  },
+  cancelText: {
+    color: '#333',
+    fontWeight:'bold',
+  },
+  confirmText: {
+    color: theme.primaryColor,
+    fontWeight:'bold',
+  },
+});

--- a/src/components/Modal/AlertModal.test.tsx
+++ b/src/components/Modal/AlertModal.test.tsx
@@ -1,0 +1,56 @@
+import {fireEvent, render} from '@testing-library/react-native';
+import {Provider} from 'react-redux';
+import {AlertModal} from './AlertModal';
+import {store} from '../../redux/store';
+
+
+const renderAlertModal = ({
+  visible = true,
+  message = 'Do you really want to delete this account?',
+  confirmText = 'Delete',
+  cancelText = 'Cancel',
+  onConfirm = () => {},
+  onCancel = () => {},
+} = {}) => {
+  return render(
+    <Provider store={store}>
+      <AlertModal
+        visible={visible}
+        message={message}
+        confirmText={confirmText}
+        cancelText={cancelText}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />
+    </Provider>,
+  );
+};
+
+describe('Alert Modal', () => {
+  it('Should render the modal with given message and buttons ', () => {
+    const {getByText} = renderAlertModal();
+    expect(
+      getByText('Do you really want to delete this account?'),
+    ).toBeTruthy();
+    expect(getByText('Delete')).toBeTruthy();
+    expect(getByText('Cancel')).toBeTruthy();
+  });
+
+  it('Should trigger onConfirm when confirm button is pressed', () => {
+    const handleConfirm = jest.fn();
+
+    const {getByText} = renderAlertModal({onConfirm: handleConfirm});
+
+    fireEvent.press(getByText('Delete'));
+    expect(handleConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('Should trigger onCancel when cancel button is pressed', () => {
+    const handleCancel = jest.fn();
+
+    const {getByText} = renderAlertModal({onCancel: handleCancel});
+
+    fireEvent.press(getByText('Cancel'));
+    expect(handleCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/Modal/AlertModal.tsx
+++ b/src/components/Modal/AlertModal.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import {
+  Modal,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import {getStyles} from './AlertModal.styles';
+import {Theme} from '../../utils/themes';
+import {useAppTheme} from '../../hooks/appTheme';
+
+interface AlertModalProps {
+  message: string;
+  visible: boolean;
+  confirmText?: string;
+  cancelText?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export const AlertModal = ({
+  message,
+  visible,
+  confirmText,
+  cancelText,
+  onConfirm,
+  onCancel,
+}: AlertModalProps) => {
+  const theme: Theme = useAppTheme();
+  const styles = getStyles(theme);
+  return (
+    <Modal
+      animationType="slide"
+      transparent={true}
+      visible={visible}
+      onRequestClose={onCancel}>
+        <View style={styles.overlay}>
+          <View style={styles.modalContainer}>
+            <Text style={styles.message}>{message}</Text>
+            <View style={styles.buttonContainer}>
+              <TouchableOpacity
+                onPress={onCancel}>
+                <Text style={styles.cancelText}>{cancelText}</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                onPress={onConfirm}>
+                <Text style={styles.confirmText}>{confirmText}</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+    </Modal>
+  );
+};

--- a/src/i18n/translations/english/home.json
+++ b/src/i18n/translations/english/home.json
@@ -10,5 +10,12 @@
     "Remove":"Remove",
     "Select contact":"Select contact",
     "Contacts on SmartChat":"Contacts on SmartChat",
-    "Invite to SmartChat":"Invite to SmartChat"
+    "Invite to SmartChat":"Invite to SmartChat",
+    "Do you really want to delete this account?":"Do you really want to delete this account?",
+    "Delete":"Delete",
+    "Cancel":"Cancel",
+    "Do you really want to sign out":"Do you really want to sign out",
+    "Sign Out":"Sign Out",
+    "Do you really want to clear this chat?":"Do you really want to clear this chat?",
+    "Clear chat":"Clear chat"
 }

--- a/src/i18n/translations/telugu/home.json
+++ b/src/i18n/translations/telugu/home.json
@@ -12,5 +12,12 @@
   "Start Conversations with your closed ones":"మీ సన్నిహితులతో సంభాషణలు ప్రారంభించండి",
   "Select contact": "ఫోన్ నెంబరు ఎంచుకోండి",
   "Contacts on SmartChat": "స్మార్ట్‌చాట్‌లో ఉన్న ఫ్రెండ్స్",
-  "Invite to SmartChat": "స్మార్ట్‌చాట్‌కు పిలవండి"
+  "Invite to SmartChat": "స్మార్ట్‌చాట్‌కు పిలవండి",
+  "Do you really want to delete this account?":"మీరు నిజంగా ఈ ఖాతాను తొలగించాలనుకుంటున్నారా?",
+  "Delete":"తొలగించు",
+  "Cancel":"తీసేయాండి",
+  "Do you really want to sign out?":"మీరు నిజంగా సైన్ అవుట్ చేయాలనుకుంటున్నారా?",
+  "Sign Out":"సైన్ అవుట్ చేయండి",
+  "Do you really want to clear this chat?":"మీరు నిజంగా ఈ చాట్‌ను క్లియర్ చేయాలనుకుంటున్నారా?",
+  "Clear chat":"చాట్‌ను క్లియర్ చేయండి"
 }


### PR DESCRIPTION
### 📌 What does this PR do ?

This PR implements designing a `reusable alert modal`.
 
- Designed a reusable alert modal, which can be used when `deleting user account`, `signing out` from account.

#### ✅ Testing:

- Unit tested using `jest` and everything is working as expected ☑️.
