### PR TITLE
Implement Unread Screen UI with initial message

### DIFF
--- a/src/i18n/translations/english/home.json
+++ b/src/i18n/translations/english/home.json
@@ -10,5 +10,7 @@
     "Remove":"Remove",
     "Select contact":"Select contact",
     "Contacts on SmartChat":"Contacts on SmartChat",
-    "Invite to SmartChat":"Invite to SmartChat"
+    "Invite to SmartChat":"Invite to SmartChat",
+    "No unread chats here":"No unread chats here",
+    "View all chats":"View all chats"
 }

--- a/src/i18n/translations/telugu/home.json
+++ b/src/i18n/translations/telugu/home.json
@@ -12,5 +12,7 @@
   "Start Conversations with your closed ones":"మీ సన్నిహితులతో సంభాషణలు ప్రారంభించండి",
   "Select contact": "ఫోన్ నెంబరు ఎంచుకోండి",
   "Contacts on SmartChat": "స్మార్ట్‌చాట్‌లో ఉన్న ఫ్రెండ్స్",
-  "Invite to SmartChat": "స్మార్ట్‌చాట్‌కు పిలవండి"
+  "Invite to SmartChat": "స్మార్ట్‌చాట్‌కు పిలవండి",
+  "No unread chats here":"ఇక్కడ చదవని చాట్‌లు లేవు",
+  "View all chats":"అన్ని చాట్‌లను వీక్షించండి"
 }

--- a/src/navigations/stacks/UnreadStack.tsx
+++ b/src/navigations/stacks/UnreadStack.tsx
@@ -1,0 +1,75 @@
+import {createNativeStackNavigator, NativeStackNavigationOptions} from '@react-navigation/native-stack';
+import {Contact} from '../../screens/Contact/Contact';
+import {getStyles} from '../../screens/Contact/Contact.styles';
+import { Unread } from '../../screens/Unread/Unread';
+import { ContactScreenNavigationProps, HomeStackParamList} from '../../types/Navigations';
+import {Image, Text, TouchableOpacity, View} from 'react-native';
+import {Theme} from '../../utils/themes';
+import {useAppTheme} from '../../hooks/appTheme';
+import '../../screens/Contact/Contact.styles';
+import { getStyles as getHomeScreenStyles } from '../../screens/Home/Home.styles';
+
+
+const Stack = createNativeStackNavigator<HomeStackParamList>();
+
+
+function GetHomeScreenOptions () {
+    const theme: Theme = useAppTheme();
+    const styles = getHomeScreenStyles(theme);
+    return {
+        headerStyle: {
+        backgroundColor: theme.primaryBackground,
+        },
+        headerTitle: '',
+        headerLeft: () => (
+        <View>
+            <Text style={styles.headerText}>SmartChat</Text>
+        </View>
+        ),
+    };
+}
+
+function getContactScreenOptions(navigation: ContactScreenNavigationProps, theme:Theme): NativeStackNavigationOptions {
+    const styles = getStyles(theme);
+
+    const handleNavigation = () =>{
+      navigation.goBack();
+    };
+    return {
+        headerShown: true,
+        headerStyle: {
+        backgroundColor: '#FFFFF',
+        },
+        headerTitle: '',
+        headerLeft: () => (
+            <View style={styles.headerLeft}>
+            <TouchableOpacity onPress={handleNavigation}>
+                <Image
+                    style={styles.backIcon}
+                    source={require('../../../assets/images/chevron.png')}
+                />
+            </TouchableOpacity>
+            <Text style={styles.headerTitle}>Select contact</Text>
+            </View>
+        ),
+        headerRight: () => (
+            <TouchableOpacity style={styles.headerRight}>
+            <Image
+                style={styles.userIcon}
+                source={theme.images.contactUser}
+            />
+            </TouchableOpacity>
+        ),
+    };
+}
+
+export function UnreadStack(): React.JSX.Element {
+    const theme: Theme = useAppTheme();
+
+  return (
+    <Stack.Navigator>
+      <Stack.Screen name="Unread" component={Unread} options={GetHomeScreenOptions()}/>
+      <Stack.Screen name="Contact" component={Contact} options={({ navigation }) => getContactScreenOptions(navigation, theme)} />
+    </Stack.Navigator>
+  );
+}

--- a/src/navigations/tabs/Tabs.tsx
+++ b/src/navigations/tabs/Tabs.tsx
@@ -7,6 +7,7 @@ import { useAppTheme } from '../../hooks/appTheme';
 import { Theme } from '../../utils/themes';
 import { HomeStack } from '../stacks/HomeStack';
 import { Profile } from '../../screens/Profile/Profile';
+import { UnreadStack } from '../stacks/UnreadStack';
 
 
 const Tab = createBottomTabNavigator<BottomTabParamList>();
@@ -80,7 +81,7 @@ export function Tabs(): React.JSX.Element {
   return (
     <Tab.Navigator screenOptions={({ route }) => getScreenOptions(route, theme)}>
       <Tab.Screen name="AllChatsTab" component={HomeStack} />
-      <Tab.Screen name="UnreadTab" component={HomeStack} />
+      <Tab.Screen name="UnreadTab" component={UnreadStack} />
       <Tab.Screen name="ProfileScreen" component={Profile} options={{headerShown: true}} />
     </Tab.Navigator>
   );

--- a/src/screens/Unread/Unread.styles.ts
+++ b/src/screens/Unread/Unread.styles.ts
@@ -1,0 +1,20 @@
+import {StyleSheet} from 'react-native';
+import {Theme} from '../../utils/themes';
+
+export const getStyles = (theme: Theme) =>
+  StyleSheet.create({
+    bodyText: {
+      fontSize: 20,
+      textAlign: 'center',
+      fontFamily: 'Nunito',
+      color: theme.primaryTextColor,
+    },
+    viewText:{
+        marginTop:15,
+        fontWeight:'bold',
+        fontSize: 20,
+        textAlign: 'center',
+        fontFamily: 'Nunito',
+        color: theme.primaryColor,
+    },
+  });

--- a/src/screens/Unread/Unread.test.tsx
+++ b/src/screens/Unread/Unread.test.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import {Provider} from 'react-redux';
+import {store} from '../../redux/store';
+import {useNavigation} from '@react-navigation/native';
+import {fireEvent, render} from '@testing-library/react-native';
+import {Unread} from './Unread';
+
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: jest.fn(),
+}));
+
+function renderUnreadScreen() {
+  return render(
+    <Provider store={store}>
+      <Unread />
+    </Provider>,
+  );
+}
+
+describe('Unread Screen', () => {
+  const mockNavigateToContact = jest.fn();
+  const mockNavigateToAllChats = jest.fn();
+
+  beforeEach(() => {
+    (useNavigation as jest.Mock)
+      .mockReturnValueOnce({ navigate: mockNavigateToContact })
+      .mockReturnValueOnce({ navigate: mockNavigateToAllChats });
+    jest.clearAllMocks();
+  });
+
+  test('should render "No unread chats here" text', () => {
+    const {getByText} = renderUnreadScreen();
+    expect(getByText(/No unread chats here/i)).toBeTruthy();
+  });
+
+  test('should render "View all chats" text', () => {
+    const {getByText} = renderUnreadScreen();
+    expect(getByText(/View all chats/i)).toBeTruthy();
+  });
+
+  test('should navigate to AllChatsTab when pressing "View all chats"', () => {
+    const {getByText} = renderUnreadScreen();
+    fireEvent.press(getByText(/View all chats/i));
+    expect(mockNavigateToAllChats).toHaveBeenCalledWith('AllChatsTab');
+  });
+
+  test('should render add contact button', () => {
+    const {getByLabelText} = renderUnreadScreen();
+    expect(getByLabelText('addContact')).toBeTruthy();
+  });
+
+  test('should navigate to Contact when pressing add contact button', () => {
+    const {getByLabelText} = renderUnreadScreen();
+    fireEvent.press(getByLabelText('addContact'));
+    expect(mockNavigateToContact).toHaveBeenCalledWith('Contact');
+  });
+});

--- a/src/screens/Unread/Unread.tsx
+++ b/src/screens/Unread/Unread.tsx
@@ -1,0 +1,41 @@
+import { getStyles } from '../Home/Home.styles';
+import {useAppTheme} from '../../hooks/appTheme';
+import React from 'react';
+import {Image, ScrollView, Text, TouchableOpacity, View} from 'react-native';
+import {useNavigation} from '@react-navigation/native';
+import {AllChatsTabScreenNavigationProps, ContactScreenNavigationProps} from '../../types/Navigations';
+import {Theme} from '../../utils/themes';
+import {getStyles as UnreadStyles} from './Unread.styles';
+
+export function Unread(): React.JSX.Element {
+  const theme: Theme = useAppTheme();
+  const styles = getStyles(theme);
+  const Ustyles = UnreadStyles(theme);
+  const navigation = useNavigation<ContactScreenNavigationProps>();
+  const navigationToAllChats = useNavigation<AllChatsTabScreenNavigationProps>();
+  return (
+    <View style={styles.container}>
+      <View style={styles.totalContainer}>
+        <ScrollView contentContainerStyle={styles.bodyContainer}>
+          <View style={styles.textContainer}>
+            <Text style={Ustyles.bodyText}>
+              No unread chats here
+            </Text>
+            <TouchableOpacity onPress={() => navigationToAllChats.navigate('AllChatsTab')}>
+            <Text style={Ustyles.viewText}>View all chats</Text>
+            </TouchableOpacity>
+          </View>
+        </ScrollView>
+        <TouchableOpacity
+          onPress={() => navigation.navigate('Contact')}
+          style={styles.addContactContainer}>
+          <Image
+            source={require('../../../assets/icons/contacts-add-icon.png')}
+            style={styles.addContactImage}
+            accessibilityLabel="addContact"
+          />
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}

--- a/src/types/Navigations.ts
+++ b/src/types/Navigations.ts
@@ -20,6 +20,8 @@ export type LogincreenNavigationProps = NativeStackNavigationProp<RootStackParam
 
 export type RegistrationScreenNavigationProps = NativeStackNavigationProp<RootStackParamList, 'RegistrationScreen'>;
 
+export type AllChatsTabScreenNavigationProps=NativeStackNavigationProp<BottomTabParamList, 'AllChatsTab'>
+
 
 export type tabBarIconProps = {
     routeName: string;
@@ -30,6 +32,7 @@ export type tabBarIconProps = {
 export type HomeStackParamList = {
     Home: undefined;
     Contact: undefined;
+    Unread:undefined;
 };
 
 export type HomeScreenNavigationProps = NativeStackNavigationProp<HomeStackParamList, 'Home'>;


### PR DESCRIPTION
### 📌 What does this PR do?

This PR implements Unread screen along with the following changes:

- Customised header for the Unread Screen.

- A user friendly message `No unread chats here` and if user can click on `view all chats` if they'd like to see them.

- An add contact button at bottom-right corner to start a conversation by selecting a desired contact.

- Added navigation for all chats screen on clicking view all chats text.

- Added navigation to contacts screen on clicking add-contact button.

### ✅Testing

- Wrote tests for all the elements of Unread screen UI are unit tested with Jest and are behaving as expected.

### General Checklist

- Linting has passed with no errors and warnings.

- All tests passed and everything works as expected.

<img width="398" alt="Screenshot 2025-05-15 at 11 02 40 AM" src="https://github.com/user-attachments/assets/e137432c-e4d9-4295-926b-b96c35a3031a" />

<img width="295" alt="Screenshot 2025-05-15 at 11 07 49 AM" src="https://github.com/user-attachments/assets/7606e8b0-277b-40a4-9644-7367c3a5259d" />
