### PR TITLE
Clear AsyncStorage and Keychain Data on First Launch (iOS)

### DIFF
--- a/ios/SmartChat/AppDelegate.swift
+++ b/ios/SmartChat/AppDelegate.swift
@@ -2,6 +2,7 @@ import UIKit
 import React
 import React_RCTAppDelegate
 import ReactAppDependencyProvider
+import Security 
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -14,6 +15,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
+    
+    if !UserDefaults.standard.bool(forKey: "hasRunBefore") {
+      clearApplicationSupportDirectory()
+      clearKeychain()
+      UserDefaults.standard.set(true, forKey: "hasRunBefore")
+      UserDefaults.standard.synchronize()
+    }
+
     let delegate = ReactNativeDelegate()
     let factory = RCTReactNativeFactory(delegate: delegate)
     delegate.dependencyProvider = RCTAppDependencyProvider()
@@ -30,6 +39,43 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     )
 
     return true
+  }
+
+  func clearApplicationSupportDirectory() {
+    let fileManager = FileManager.default
+
+    do {
+      let appSupportURL = try fileManager.url(
+        for: .applicationSupportDirectory,
+        in: .userDomainMask,
+        appropriateFor: nil,
+        create: true
+      )
+
+      let contents = try fileManager.contentsOfDirectory(atPath: appSupportURL.path)
+
+      for item in contents {
+        let itemPath = appSupportURL.appendingPathComponent(item).path
+        try fileManager.removeItem(atPath: itemPath)
+      }
+    } catch {
+      print("Error clearing Application Support directory: \(error)")
+    }
+  }
+
+  func clearKeychain() {
+    let secItemClasses = [
+      kSecClassGenericPassword,
+      kSecClassInternetPassword,
+      kSecClassCertificate,
+      kSecClassKey,
+      kSecClassIdentity
+    ]
+
+    for itemClass in secItemClasses {
+      let query: [String: Any] = [kSecClass as String: itemClass]
+      SecItemDelete(query as CFDictionary)
+    }
   }
 }
 


### PR DESCRIPTION
📌 What does this PR do?

- This PR adds logic to clear persisted encrypted asyncStorage when the app is launched for the first time after installation on iOS.

Changes made:
- Added `clearApplicationSupportDirectory()` to remove app support files.
- Added `clearKeychain()` to delete stored Keychain entries.
- Used `UserDefaults` flag (`hasRunBefore`) to ensure this logic runs only once after install.

✅ Testing:
- Linting passed with no errors.
- Executed Jest test cases.
