### PR TITLE
Chat alert modals

### DIFF
--- a/src/components/ChatOptionsModal/ChatOptionsModal.test.tsx
+++ b/src/components/ChatOptionsModal/ChatOptionsModal.test.tsx
@@ -1,8 +1,8 @@
-import { render, screen, fireEvent } from '@testing-library/react-native';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { Platform } from 'react-native';
 import { Provider } from 'react-redux';
 import { store } from '../../redux/store';
 import { ChatOptionsModal } from './ChatOptionsModal';
-import { Platform } from 'react-native';
 const renderChatOptionsModal = ({
   visible = true,
   onClearChat = jest.fn(),
@@ -17,7 +17,7 @@ const renderChatOptionsModal = ({
         onBlock={onBlock}
         onClose={onClose}
       />
-    </Provider>
+    </Provider>,
   );
 };
 
@@ -31,23 +31,39 @@ describe('ChatOptionsModal Component', () => {
 
   it('should call onClearChat when "Clear Chat" is pressed', () => {
     const handleClearChat = jest.fn();
-    renderChatOptionsModal({ onClearChat: handleClearChat });
+    renderChatOptionsModal({onClearChat: handleClearChat});
 
     fireEvent.press(screen.getByText('Clear Chat'));
+    fireEvent.press(screen.getByText('Yes'));
     expect(handleClearChat).toHaveBeenCalledTimes(1);
   });
 
   it('should call onBlock when "Block" is pressed', () => {
     const handleBlock = jest.fn();
-    renderChatOptionsModal({ onBlock: handleBlock });
+    renderChatOptionsModal({onBlock: handleBlock});
 
     fireEvent.press(screen.getByText('Block'));
+    fireEvent.press(screen.getByText('Yes'));
     expect(handleBlock).toHaveBeenCalledTimes(1);
+  });
+  it('should close clear alert when "Cancel" is pressed', () => {
+    renderChatOptionsModal();
+
+    fireEvent.press(screen.getByText('Clear Chat'));
+    fireEvent.press(screen.getByText('Cancel'));
+    expect(screen.queryByText('Cancel')).toBeNull();
+  });
+  it('should close block alert when " Cancel" is pressed', () => {
+    renderChatOptionsModal();
+
+    fireEvent.press(screen.getByText('Block'));
+    fireEvent.press(screen.getByText('Cancel'));
+    expect(screen.queryByText('Cancel')).toBeNull();
   });
 
   it('should call onClose when clicking outside the modal', () => {
     const handleClose = jest.fn();
-    renderChatOptionsModal({ onClose: handleClose });
+    renderChatOptionsModal({onClose: handleClose});
 
     fireEvent.press(screen.getByLabelText('overlay'));
     expect(handleClose).toHaveBeenCalledTimes(1);
@@ -55,21 +71,21 @@ describe('ChatOptionsModal Component', () => {
 
   it('should apply correct paddingTop based on the platform (Android)', () => {
     Platform.OS = 'android';
-    const { getByLabelText } = renderChatOptionsModal();
+    const {getByLabelText} = renderChatOptionsModal();
 
     const overlayView = getByLabelText('overlay');
     const styles = overlayView.props.style;
 
-    expect(styles).toContainEqual({ paddingTop: 50 });
+    expect(styles).toContainEqual({paddingTop: 50});
   });
 
   it('should apply correct paddingTop based on the platform (iOS)', () => {
     Platform.OS = 'ios';
-    const { getByLabelText } = renderChatOptionsModal();
+    const {getByLabelText} = renderChatOptionsModal();
 
     const overlayView = getByLabelText('overlay');
     const styles = overlayView.props.style;
 
-    expect(styles).toContainEqual({ paddingTop: 101 });
+    expect(styles).toContainEqual({paddingTop: 101});
   });
 });

--- a/src/components/ChatOptionsModal/ChatOptionsModal.tsx
+++ b/src/components/ChatOptionsModal/ChatOptionsModal.tsx
@@ -1,15 +1,16 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {
-  View,
-  Text,
   Modal,
+  Platform,
+  Text,
   TouchableOpacity,
   TouchableWithoutFeedback,
-  Platform,
+  View,
 } from 'react-native';
-import {Theme} from '../../utils/themes';
 import {useAppTheme} from '../../hooks/appTheme';
-import { getStyles } from './ChatOptionsModal.styles';
+import {Theme} from '../../utils/themes';
+import {AlertModal} from '../AlertModal/AlertModal';
+import {getStyles} from './ChatOptionsModal.styles';
 
 type ChatBlockModalProps = {
   visible: boolean;
@@ -26,25 +27,58 @@ export const ChatOptionsModal = ({
 }: ChatBlockModalProps) => {
   const theme: Theme = useAppTheme();
   const styles = getStyles(theme);
+
+  const [showClearAlert, setShowClearAlert] = useState(false);
+  const [showBlockAlert, setShowBlockAlert] = useState(false);
+
   return (
-    <Modal
-      transparent
-      animationType="fade"
-      visible={visible}
-      onRequestClose={onClose}
-      >
-      <TouchableWithoutFeedback onPress={onClose} >
-        <View style={Platform.OS === 'android' ? [styles.overlay, {paddingTop: 50}] : [styles.overlay, {paddingTop: 101}]}  accessibilityLabel="overlay">
-            <View style={styles.modalContainer} >
-              <TouchableOpacity onPress={onClearChat}>
+    <>
+      <Modal
+        transparent
+        animationType="fade"
+        visible={visible}
+        onRequestClose={onClose}>
+        <TouchableWithoutFeedback onPress={onClose}>
+          <View
+            style={
+              Platform.OS === 'android'
+                ? [styles.overlay, {paddingTop: 50}]
+                : [styles.overlay, {paddingTop: 101}]
+            }
+            accessibilityLabel="overlay">
+            <View style={styles.modalContainer}>
+              <TouchableOpacity onPress={() => setShowClearAlert(true)}>
                 <Text style={styles.text}>Clear Chat</Text>
               </TouchableOpacity>
-              <TouchableOpacity onPress={onBlock}>
+              <TouchableOpacity onPress={() => setShowBlockAlert(true)}>
                 <Text style={styles.text}>Block</Text>
               </TouchableOpacity>
             </View>
-        </View>
-      </TouchableWithoutFeedback>
-    </Modal>
+          </View>
+        </TouchableWithoutFeedback>
+        <AlertModal
+          message={'Do you really want to clear this chat?'}
+          visible={showClearAlert}
+          confirmText={'Yes'}
+          cancelText={'Cancel'}
+          onConfirm={() => {
+            setShowClearAlert(false);
+            onClearChat();
+          }}
+          onCancel={() => setShowClearAlert(false)}
+        />
+        <AlertModal
+          message={'Are you sure you want to block this chat?'}
+          visible={showBlockAlert}
+          confirmText={'Yes'}
+          cancelText={'Cancel'}
+          onConfirm={() => {
+            setShowBlockAlert(false);
+            onBlock();
+          }}
+          onCancel={() => setShowBlockAlert(false)}
+        />
+      </Modal>
+    </>
   );
 };

--- a/src/components/Menu/Menu.test.tsx
+++ b/src/components/Menu/Menu.test.tsx
@@ -1,57 +1,71 @@
-import { render, screen, fireEvent } from '@testing-library/react-native';
-import { Menu } from './Menu';
-import { Provider } from 'react-redux';
-import { store } from '../../redux/store';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react-native';
+import {Provider} from 'react-redux';
+import {store} from '../../redux/store';
+import {Menu} from './Menu';
 
 describe('Tests related to Menu component', () => {
   it('should render the menu image', () => {
     render(
       <Provider store={store}>
         <Menu />
-      </Provider>
+      </Provider>,
     );
     expect(screen.getByLabelText('Menu-Image')).toBeTruthy();
   });
 
-  it('should close the modal when "Clear Chat" is pressed', () => {
+  it('should close the modal when "Clear Chat" is pressed', async () => {
     render(
       <Provider store={store}>
         <Menu />
-      </Provider>
+      </Provider>,
     );
 
     fireEvent.press(screen.getByLabelText('Menu-Image'));
     expect(screen.getByText('Clear Chat')).toBeTruthy();
 
     fireEvent.press(screen.getByText('Clear Chat'));
-    expect(screen.queryByText('Clear Chat')).toBeNull();
+    fireEvent.press(screen.getByText('Yes'));
+    await waitFor(() => {
+      expect(screen.queryByText('Clear Chat')).toBeNull();
+    });
   });
 
-  it('should close the modal when "Block" is pressed', () => {
+  it('should close the modal when "Block" is pressed', async () => {
     render(
       <Provider store={store}>
         <Menu />
-      </Provider>
+      </Provider>,
     );
 
     fireEvent.press(screen.getByLabelText('Menu-Image'));
     expect(screen.getByText('Block')).toBeTruthy();
 
     fireEvent.press(screen.getByText('Block'));
-    expect(screen.queryByText('Block')).toBeNull();
+    fireEvent.press(screen.getByText('Yes'));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Block')).toBeNull();
+    });
   });
 
-  it('should close the modal when clicking outside the modal (overlay)', () => {
+  it('should close the modal when clicking outside the modal (overlay)', async () => {
     render(
       <Provider store={store}>
         <Menu />
-      </Provider>
+      </Provider>,
     );
 
     fireEvent.press(screen.getByLabelText('Menu-Image'));
     expect(screen.getByText('Clear Chat')).toBeTruthy();
 
     fireEvent.press(screen.getByLabelText('overlay'));
-    expect(screen.queryByText('Clear Chat')).toBeNull();
+    await waitFor(() => {
+      expect(screen.queryByText('Clear Chat')).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
### 📌 What does this PR do ?

This PR implements adding clear chat and block alert modals when the clear chat and block options are clicked in `Individual chat screen.
`
- Adds reusable `alert modal` for clear chat and block functionalities.


#### ✅ Testing :

- Unit tested using `jest` and everything is working as expected .

#### UI :
<img width="340" alt="Screenshot 2025-05-25 at 12 12 07 PM" src="https://github.com/user-attachments/assets/ecd2fd3c-0d8e-40c3-80fc-70f51c5600de" />
<img width="340" alt="Screenshot 2025-05-25 at 12 11 55 PM" src="https://github.com/user-attachments/assets/60079fb5-31a6-4452-b2c1-ce3e3c05720f" />
