### PR TITLE
Implement API integration to fetch undelivered messages and store in local database

### DIFF
--- a/src/navigations/AppNavigator.tsx
+++ b/src/navigations/AppNavigator.tsx
@@ -18,6 +18,8 @@ import { checkAccessToken } from '../utils/checkToken.ts';
 import { socketConnection } from '../utils/socket.ts';
 import { Tabs } from './tabs/Tabs.tsx';
 import { setSuccessMessage } from '../redux/reducers/auth.reducer.ts';
+import { useRealm } from '../contexts/RealmContext.tsx';
+import { storeMessages } from '../utils/storeMessages.ts';
 
 
 
@@ -27,6 +29,7 @@ export function AppNavigator(): React.JSX.Element {
 
     const [isUserStored, setIsUserStored] = useState<boolean>(false);
     const [isReady, setIsReady] = useState<boolean>(false);
+     const realm = useRealm();
     const dispatch = useDispatch();
     const {
         alertVisible, alertMessage, alertType, showAlert, hideAlert,
@@ -53,6 +56,9 @@ export function AppNavigator(): React.JSX.Element {
             await getDBConnection();
             const dbInstance = await getDBinstance();
             await createContactsTable(dbInstance);
+            if(netState.isConnected){
+                await storeMessages(user.mobileNumber,realm);
+             }
             setIsUserStored(true);
           }
         } catch (error) {
@@ -63,7 +69,7 @@ export function AppNavigator(): React.JSX.Element {
         }
       };
       loadUser();
-    }, [dispatch, showAlert]);
+    }, [dispatch, realm, showAlert]);
 
     if(!isReady) {
       return <></>;

--- a/src/realm-database/operations/updateMessageStatus.test.ts
+++ b/src/realm-database/operations/updateMessageStatus.test.ts
@@ -82,9 +82,11 @@ describe('updateMessageStatusInRealm', () => {
     const message2 = { sentAt: '2025-06-01T00:00:00Z', status: 'delivered' };
     const newer = { sentAt: '2025-06-02T00:00:00Z', status: 'sent' };
 
+    const messageIds= [message1.sentAt, message2.sentAt, newer.sentAt];
+
     mockMessages.push(message1, message2, newer);
 
-    await updateMessageStatusInRealm({ chatId, sentAt, status, updateAllBeforeSentAt: true });
+    await updateMessageStatusInRealm({ chatId, sentAt, status, updateAllBeforeSentAt: true, messageIds: messageIds });
 
     expect(message1.status).toBe(status);
     expect(message2.status).toBe(status);

--- a/src/realm-database/operations/updateMessageStatus.ts
+++ b/src/realm-database/operations/updateMessageStatus.ts
@@ -6,6 +6,7 @@ type UpdateMessageStatusParams = {
   sentAt: string;
   status: 'sent' | 'delivered' | 'seen';
   updateAllBeforeSentAt?: boolean;
+  messageIds?: string[];
 };
 
 export const updateMessageStatusInRealm = async ({
@@ -13,6 +14,7 @@ export const updateMessageStatusInRealm = async ({
   sentAt,
   status,
   updateAllBeforeSentAt,
+  messageIds,
 }: UpdateMessageStatusParams) => {
   const realm = getRealmInstance();
 
@@ -22,14 +24,18 @@ export const updateMessageStatusInRealm = async ({
       const messages = realm.objects<Message>('Message').filtered('chat.chatId == $0 AND isSender == true', chatId).sorted('sentAt');
 
       if (updateAllBeforeSentAt) {
-        for (let i = messages.length - 1; i >= 0; i--) {
-          const message = messages[i];
+        for (let index = messages.length - 1; index >= 0; index--) {
+          const message = messages[index];
+          if(messageIds && messageIds.includes(message.sentAt)){
           if (message.sentAt <= sentAt && message.status !== status) {
+
             message.status = status;
+
           } else {
             break;
           }
-        }
+          }
+         }
       } else {
         const message = messages.filtered('sentAt == $0', sentAt)[0];
         if (message) {

--- a/src/types/message.ts
+++ b/src/types/message.ts
@@ -7,6 +7,15 @@ export interface Message {
 export type DBMessage = Message & {
   nonce: string,
 }
+export type UserMessage = {
+  chatId: string;
+  message: string;
+  nonce: string;
+  sentAt: string;
+  status: 'sent' | 'delivered' | 'seen';
+};
+
+export type UserChatData = Record<string, UserMessage[]>;
 
 export interface Messages {
   [chatId: string]: Message[];

--- a/src/utils/getUserMessages.test.ts
+++ b/src/utils/getUserMessages.test.ts
@@ -1,0 +1,32 @@
+import { getUserMessages } from './getUserMessages';
+
+global.fetch = jest.fn();
+
+describe('test getUserMessages API request service', () => {
+  const mockMobileNumber = '+91 99999 00001';
+  const mockToken = 'access-token';
+
+  beforeEach(() => {
+    (fetch as jest.Mock).mockClear();
+  });
+
+  it('should call fetch with correct URL and headers', async () => {
+    const mockResponse = {
+      ok: true,
+      json: jest.fn().mockResolvedValue({}),
+    };
+    (fetch as jest.Mock).mockResolvedValue(mockResponse);
+
+    const response = await getUserMessages(mockMobileNumber, mockToken);
+
+    expect(fetch).toHaveBeenCalledWith(expect.stringContaining('user/messages'), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'smart-chat-token-header-key': `Bearer ${mockToken}`,
+      },
+      body: JSON.stringify({ mobileNumber: mockMobileNumber }),
+    });
+     expect(response).toBe(mockResponse);
+  });
+});

--- a/src/utils/getUserMessages.ts
+++ b/src/utils/getUserMessages.ts
@@ -1,0 +1,18 @@
+import { BASE_URL } from './constants';
+
+export const getUserMessages = async (
+  mobileNumber: string,
+  access_token: string,
+) => {
+  const response = await fetch(`${BASE_URL}user/messages`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'smart-chat-token-header-key': `Bearer ${access_token}`,
+    },
+    body: JSON.stringify({
+      mobileNumber: mobileNumber,
+    }),
+  });
+  return response;
+};

--- a/src/utils/socket.ts
+++ b/src/utils/socket.ts
@@ -51,13 +51,13 @@ export const socketConnection = async (mobileNumber: string) => {
       });
 
       socket.on('messageDelivered', async data => {
-        const { sentAt, receiverMobileNumber, status } = data;
-        updateMessageStatusInRealm( {chatId: receiverMobileNumber, sentAt: sentAt, status: status});
+        const { sentAt, receiverMobileNumber, status, messageIds, messagesCountToupdate } = data;
+        updateMessageStatusInRealm( {chatId: receiverMobileNumber, sentAt: sentAt, status: status, updateAllBeforeSentAt: messagesCountToupdate, messageIds: messageIds});
       });
 
       socket.on('messageRead', data => {
-        const { sentAt, chatId, status, updatedCount } = data;
-        updateMessageStatusInRealm( {chatId: chatId, sentAt: sentAt, status: status, updateAllBeforeSentAt: updatedCount > 1});
+        const { sentAt, chatId, status, updatedCount, messageIds } = data;
+        updateMessageStatusInRealm( {chatId: chatId, sentAt: sentAt, messageIds: messageIds, status: status, updateAllBeforeSentAt: updatedCount > 1});
       });
       socket.on('force-logout', () => {
         store.dispatch(clearSuccessMessage());

--- a/src/utils/storeMessages.test.ts
+++ b/src/utils/storeMessages.test.ts
@@ -1,10 +1,10 @@
-import { storeMessages } from './storeMessages';
+import Realm from 'realm';
+import { storeChats } from '../realm-database/operations/storeChats';
+import { formatMessages } from '../screens/Login/Login.service';
+import { Chat, Messages, MessageStatus, UserChatData } from '../types/message';
 import { getTokens } from './getTokens';
 import { getUserMessages } from './getUserMessages';
-import { formatMessages } from '../screens/Login/Login.service';
-import { storeChats } from '../realm-database/operations/storeChats';
-import { Chat, Messages, MessageStatus, UserChatData } from '../types/message';
-import Realm from 'realm';
+import { storeMessages } from './storeMessages';
 
 jest.mock('react-native-encrypted-storage', () => ({
   setItem: jest.fn(),

--- a/src/utils/storeMessages.test.ts
+++ b/src/utils/storeMessages.test.ts
@@ -1,0 +1,115 @@
+import { storeMessages } from './storeMessages';
+import { getTokens } from './getTokens';
+import { getUserMessages } from './getUserMessages';
+import { formatMessages } from '../screens/Login/Login.service';
+import { storeChats } from '../realm-database/operations/storeChats';
+import { Chat, Messages, MessageStatus, UserChatData } from '../types/message';
+import Realm from 'realm';
+
+jest.mock('react-native-encrypted-storage', () => ({
+  setItem: jest.fn(),
+  getItem: jest.fn(),
+  removeItem: jest.fn(),
+  getAllKeys: jest.fn(),
+  clear: jest.fn(),
+}));
+
+jest.mock('react-native-libsodium', () => ({
+  crypto_box_open_easy: jest.fn(),
+  crypto_box_seal_open: jest.fn(),
+}));
+jest.mock('../screens/Login/Login.service', () => ({
+  formatMessages: jest.fn(),
+}));
+
+jest.mock('./decryptMessage');
+global.fetch = jest.fn();
+
+jest.mock('react-native-device-info', () => ({
+  getDeviceId: jest.fn(),
+}));
+jest.mock('./getTokens');
+jest.mock('./getUserMessages');
+jest.mock('../realm-database/operations/storeChats');
+
+const mockedGetTokens = getTokens as jest.MockedFunction<typeof getTokens>;
+const mockedGetUserMessages = getUserMessages as jest.MockedFunction<typeof getUserMessages>;
+const mockedFormatMessages = formatMessages as jest.MockedFunction<typeof formatMessages>;
+const mockedStoreChats = storeChats as jest.MockedFunction<typeof storeChats>;
+
+describe('tests toreMessages functionality', () => {
+  const mockMobileNumber = '+91 99999 00001';
+  const mockRealm = {} as Realm;
+
+  const userChatData: UserChatData = {
+    '+91 99999 00002': [
+      {
+        chatId: '+91 99999 00002',
+        message: 'Hello!',
+        nonce: 'abc123',
+        sentAt: '2023-01-01T00:00:00.000Z',
+        status: 'delivered',
+      },
+    ],
+  };
+
+  const formattedChats: Chat[] = [
+    {
+      chatId: '+91 99999 00002',
+      messages: [
+        {
+          message: 'Hello!',
+          nonce: 'abc123',
+          sentAt: '2023-01-01T00:00:00.000Z',
+          status: 'delivered',
+          isSender: false,
+        },
+      ],
+    },
+  ];
+
+  const formattedMessages: Messages = {
+    '+91 99999 00002': [
+      {
+        message: 'Decrypted Hello!',
+        sentAt: '2023-01-01T00:00:00.000Z',
+        isSender: false,
+        status: MessageStatus.DELIVERED,
+      },
+    ],
+  };
+
+  it('should fetch, format, and store messages correctly', async () => {
+    mockedGetTokens.mockResolvedValue({
+      access_token: 'mocked-token',
+      refresh_token: 'mocked-refresh',
+    });
+
+    mockedGetUserMessages.mockResolvedValue({
+      ok: true,
+      json: async () => ({ chats: userChatData }),
+    } as Response);
+
+    mockedFormatMessages.mockResolvedValue(formattedMessages);
+
+    await storeMessages(mockMobileNumber, mockRealm);
+
+    expect(mockedGetTokens).toHaveBeenCalledWith(mockMobileNumber);
+    expect(mockedGetUserMessages).toHaveBeenCalledWith(mockMobileNumber, 'mocked-token');
+    expect(mockedFormatMessages).toHaveBeenCalledWith(formattedChats, 'mocked-token');
+    expect(mockedStoreChats).toHaveBeenCalledWith(mockRealm, formattedMessages);
+  });
+
+  it('should throw error in case of fetch fails and any error', async () => {
+    mockedGetTokens.mockRejectedValue(new Error('Token fetch failed'));
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    await storeMessages(mockMobileNumber, mockRealm);
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'error in fetch unsend messages',
+      expect.any(Error),
+    );
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/utils/storeMessages.ts
+++ b/src/utils/storeMessages.ts
@@ -1,0 +1,32 @@
+import { storeChats } from '../realm-database/operations/storeChats';
+import { formatMessages } from '../screens/Login/Login.service';
+import { Chat, UserChatData } from '../types/message';
+import { getUserMessages } from './getUserMessages';
+import { getTokens } from './getTokens';
+import Realm from 'realm';
+
+export const storeMessages = async (mobileNumber: string, realm: Realm) => {
+  try {
+    const tokens = await getTokens(mobileNumber);
+    const response = await getUserMessages(mobileNumber, tokens.access_token);
+    if (response.ok) {
+      const result = await response.json();
+      const chats = result.chats as UserChatData;
+      const formattedUserMessages = Object.entries(chats).map(([chatId, messages]) => ({
+        chatId,
+        messages: messages.map(messageRecord => ({
+          message: messageRecord.message,
+          nonce: messageRecord.nonce,
+          sentAt: messageRecord.sentAt,
+          status: messageRecord.status,
+          isSender: false,
+        })),
+      }));
+      const formattedMessages = await formatMessages(formattedUserMessages as Chat[], tokens.access_token);
+      storeChats(realm, formattedMessages);
+
+    }
+  } catch (error) {
+    console.log('error in fetch unsend messages', error);
+  }
+};

--- a/src/utils/storeMessages.ts
+++ b/src/utils/storeMessages.ts
@@ -1,9 +1,9 @@
+import Realm from 'realm';
 import { storeChats } from '../realm-database/operations/storeChats';
 import { formatMessages } from '../screens/Login/Login.service';
 import { Chat, UserChatData } from '../types/message';
-import { getUserMessages } from './getUserMessages';
 import { getTokens } from './getTokens';
-import Realm from 'realm';
+import { getUserMessages } from './getUserMessages';
 
 export const storeMessages = async (mobileNumber: string, realm: Realm) => {
   try {


### PR DESCRIPTION
#### 📌 This PR includes the following changes..
- Implements a service to make a fetch request for undelivered messages.
- Formats the fetched messages and then stores it in local database.
- Modified and updated new test cases for fetch request and storing messages.
- Modified message update status logic to update bunch of messages status at once.
- Handled the message status updation to update only unblocked messages and not the blocked ones.

#### 🧪 Testing
- All the functionalities and components are unit-tested with jest and are working as expected.

Thank you 😊:)