### PR TITLE
Handle deleted account chats

### DIFF
--- a/src/realm-database/operations/updateUserAccountStatus.test.ts
+++ b/src/realm-database/operations/updateUserAccountStatus.test.ts
@@ -1,0 +1,72 @@
+import { updateUserAccountStatusInRealm } from './updateUserAccountStatus';
+import { getRealmInstance } from '../connection';
+
+jest.mock('../connection', () => ({
+  getRealmInstance: jest.fn(),
+}));
+
+describe('updateUserAccountStatusInRealm', () => {
+  const mockWrite = jest.fn((fn) => fn());
+  const mockObjectForPrimaryKey = jest.fn();
+
+  const chatId = '8639523822';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (getRealmInstance as jest.Mock).mockReturnValue({
+      write: mockWrite,
+      objectForPrimaryKey: mockObjectForPrimaryKey,
+    });
+  });
+
+  it('should update isAccountDeleted to true if chat exists', () => {
+    const mockChat = { chatId, isAccountDeleted: false };
+    mockObjectForPrimaryKey.mockReturnValue(mockChat);
+
+    updateUserAccountStatusInRealm(chatId, true);
+
+    expect(getRealmInstance).toHaveBeenCalled();
+    expect(mockWrite).toHaveBeenCalled();
+    expect(mockObjectForPrimaryKey).toHaveBeenCalledWith('Chat', chatId);
+    expect(mockChat.isAccountDeleted).toBe(true);
+  });
+
+  it('should update isAccountDeleted to false if chat exists', () => {
+    const mockChat = { chatId, isAccountDeleted: true };
+    mockObjectForPrimaryKey.mockReturnValue(mockChat);
+
+    updateUserAccountStatusInRealm(chatId, false);
+
+    expect(mockObjectForPrimaryKey).toHaveBeenCalledWith('Chat', chatId);
+    expect(mockChat.isAccountDeleted).toBe(false);
+  });
+
+  it('should do nothing if chat does not exist', () => {
+    mockObjectForPrimaryKey.mockReturnValue(null);
+
+    updateUserAccountStatusInRealm(chatId, true);
+
+    expect(mockObjectForPrimaryKey).toHaveBeenCalledWith('Chat', chatId);
+    expect(mockWrite).toHaveBeenCalled();
+  });
+
+  it('should console error that were thrown to catch block', () => {
+    const error = new Error('Error');
+
+    (getRealmInstance as jest.Mock).mockReturnValue({
+      write: jest.fn(() => {
+        throw error;
+      }),
+      objectForPrimaryKey: mockObjectForPrimaryKey,
+    });
+
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    updateUserAccountStatusInRealm(chatId, true);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Error while updating message status:', error);
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/src/realm-database/operations/updateUserAccountStatus.ts
+++ b/src/realm-database/operations/updateUserAccountStatus.ts
@@ -1,0 +1,16 @@
+import { Chat } from '../schemas/Chat';
+import { getRealmInstance } from '../connection';
+
+export const updateUserAccountStatusInRealm = ( chatId: string, isAccountDeleted: boolean) => {
+  const realm = getRealmInstance();
+  try {
+    realm.write(() => {
+    let chat = realm.objectForPrimaryKey<Chat>('Chat', chatId);
+    if(chat) {
+       chat.isAccountDeleted = isAccountDeleted;
+    }
+    });
+  } catch (error) {
+    console.error('Error while updating message status:', error);
+  }
+};

--- a/src/realm-database/schemas/Chat.ts
+++ b/src/realm-database/schemas/Chat.ts
@@ -6,6 +6,7 @@ export class Chat extends Realm.Object<Chat> {
   isBlocked!: boolean;
   publicKey!: string | null;
   messages!: Realm.List<Message>;
+  isAccountDeleted!: boolean;
 
   static schema: Realm.ObjectSchema = {
     name: 'Chat',
@@ -19,7 +20,7 @@ export class Chat extends Realm.Object<Chat> {
         objectType: 'Message',
         property: 'chat',
       },
+      isAccountDeleted: { type: 'bool', default: false },
     },
   };
 }
-

--- a/src/screens/Contact/Contact.test.tsx
+++ b/src/screens/Contact/Contact.test.tsx
@@ -168,7 +168,9 @@ describe('Contacts Screen', () => {
     await waitFor(() => {
       renderContactScreen();
     });
-    expect(screen.getByText('Anjani')).toBeTruthy();
+    waitFor(()=>{
+      expect(screen.getByText('Anjani')).toBeTruthy();
+    });
   });
 
   it('should switch to Invite tab and show contacts who are not on app', async () => {

--- a/src/screens/IndividualChat/IndividualChat.test.tsx
+++ b/src/screens/IndividualChat/IndividualChat.test.tsx
@@ -215,6 +215,12 @@ describe('IndividualChat', () => {
   (updateMessageStatusInRealm as jest.Mock).mockReturnValue({});
 
     renderComponent();
+    await waitFor(() => {
+      expect(mockEmit).toHaveBeenCalledWith('isAccountDeleted', {
+        senderMobileNumber: '',
+        receiverMobileNumber: '+91 86395 23822',
+      });
+    });
 
     await waitFor(() => {
       expect(mockEmit).toHaveBeenCalledWith('messageRead', {
@@ -238,6 +244,7 @@ describe('IndividualChat', () => {
     mockRealm.objectForPrimaryKey.mockReturnValue({
       chatId: '+91 86395 23822',
       isBlocked: true,
+      isAccountDeleted: false,
       publicKey: null,
     });
 
@@ -248,6 +255,40 @@ describe('IndividualChat', () => {
     const { getByText } = renderComponent();
 
     expect(getByText(/You have blocked this contact/i)).toBeTruthy();
+  });
+
+  test('renders account deleted message box when other user account is deleted', () => {
+    mockRealm.objectForPrimaryKey.mockReturnValue({
+      chatId: '+91 86395 23822',
+      isBlocked: false,
+      isAccountDeleted: true,
+      publicKey: null,
+    });
+
+    (useQuery as jest.Mock).mockReturnValue({
+      filtered: jest.fn().mockReturnValue([]),
+    });
+
+    const { getByText } = renderComponent();
+
+    expect(getByText(/This user has deleted their account/i)).toBeTruthy();
+  });
+
+  test('renders account deleted message box when other user account is deleted and blocks the chat', () => {
+    mockRealm.objectForPrimaryKey.mockReturnValue({
+      chatId: '+91 86395 23822',
+      isBlocked: true,
+      isAccountDeleted: true,
+      publicKey: null,
+    });
+
+    (useQuery as jest.Mock).mockReturnValue({
+      filtered: jest.fn().mockReturnValue([]),
+    });
+
+    const { getByText } = renderComponent();
+
+    expect(getByText(/This user has deleted their account/i)).toBeTruthy();
   });
 
 });

--- a/src/screens/IndividualChat/IndividualChat.tsx
+++ b/src/screens/IndividualChat/IndividualChat.tsx
@@ -71,10 +71,13 @@ export const IndividualChat = () => {
     if (!socket?.connected) {
       return;
     }
-    socket.emit('isAccountDeleted', {
-      senderMobileNumber: user.mobileNumber,
-      receiverMobileNumber: mobileNumber,
-    });
+    if(chat && !chat.isAccountDeleted) {
+      socket.emit('isAccountDeleted', {
+        senderMobileNumber: user.mobileNumber,
+        receiverMobileNumber: mobileNumber,
+      });
+    }
+
     if (!messages.length) {
       return;
     }
@@ -90,7 +93,7 @@ export const IndividualChat = () => {
       });
       updateMessageStatusInRealm( {chatId: mobileNumber, sentAt: latestUnseen.sentAt, status: 'seen', updateAllBeforeSentAt: true});
     }
-  }, [messages, mobileNumber, user.mobileNumber]);
+  }, [chat, messages, mobileNumber, user.mobileNumber]);
 
   const renderChatHeader = useCallback(
     () => (

--- a/src/screens/IndividualChat/IndividualChat.tsx
+++ b/src/screens/IndividualChat/IndividualChat.tsx
@@ -67,15 +67,17 @@ export const IndividualChat = () => {
   }, [chat, mobileNumber, realm]);
 
   useEffect(() => {
-    if (!messages.length) {
-      return;
-    }
-
     const socket = getSocket();
     if (!socket?.connected) {
       return;
     }
-
+    socket.emit('isAccountDeleted', {
+      senderMobileNumber: user.mobileNumber,
+      receiverMobileNumber: mobileNumber,
+    });
+    if (!messages.length) {
+      return;
+    }
     const reversedMessages = [...messages].reverse();
     const latestUnseen = reversedMessages.find(
       msg => !msg.isSender && msg.status !== 'seen',
@@ -88,7 +90,7 @@ export const IndividualChat = () => {
       });
       updateMessageStatusInRealm( {chatId: mobileNumber, sentAt: latestUnseen.sentAt, status: 'seen', updateAllBeforeSentAt: true});
     }
-  }, [messages, mobileNumber]);
+  }, [messages, mobileNumber, user.mobileNumber]);
 
   const renderChatHeader = useCallback(
     () => (
@@ -206,13 +208,14 @@ export const IndividualChat = () => {
         />
         </View>
 
-        {!chat?.isBlocked ? <View style={styles.inputContainer}>
+        {!chat?.isBlocked && !chat?.isAccountDeleted ? <View style={styles.inputContainer}>
           <InputChatBox receiverMobileNumber={mobileNumber} />
           </View> :
         <View style={styles.blockedMessageContainer}>
           <View style={styles.box}>
             <Text style={styles.blockedText}>
-              You have blocked this contact. Unblock to send or receive messages.
+            { chat?.isAccountDeleted && 'This user has deleted their account.\n You can no longer send messages'}
+             { !chat?.isAccountDeleted && chat?.isBlocked && 'You have blocked this contact. Unblock to send or receive messages.'}
             </Text>
           </View>
         </View>

--- a/src/utils/socket.test.ts
+++ b/src/utils/socket.test.ts
@@ -6,6 +6,7 @@ import { socketConnection, socketDisconnect } from './socket';
 import { getRealmInstance } from '../realm-database/connection';
 import { updateMessageStatusInRealm } from '../realm-database/operations/updateMessageStatus';
 import { addNewMessageInRealm } from '../realm-database/operations/addNewMessage';
+import { updateUserAccountStatusInRealm } from '../realm-database/operations/updateUserAccountStatus';
 
 jest.mock('react-native-encrypted-storage', () => ({
   getItem: jest.fn(),
@@ -21,6 +22,10 @@ jest.mock('../realm-database/operations/addNewMessage', () => ({
 
 jest.mock('../realm-database/operations/updateMessageStatus', () => ({
   updateMessageStatusInRealm: jest.fn(),
+}));
+
+jest.mock('../realm-database/operations/updateUserAccountStatus', () => ({
+  updateUserAccountStatusInRealm: jest.fn(),
 }));
 
 jest.mock('socket.io-client', () => ({
@@ -180,6 +185,22 @@ describe('Socket Utility (with Realm instance mocking)', () => {
       updateAllBeforeSentAt: true,
     });
   });
+
+    it('should handle isAccountDeleted and call updateUserAccountStatusInRealm', async () => {
+      const deliveryData = {
+        isAccountDeleted: true,
+        chatId: mobileNumber,
+      };
+
+      await socketConnection(mobileNumber);
+      const handler = mockOn.mock.calls.find(call => call[0] === 'isAccountDeleted')?.[1];
+      handler?.(deliveryData);
+
+      expect(updateUserAccountStatusInRealm).toHaveBeenCalledWith(
+        mobileNumber,
+        true,
+      );
+    });
 
   it('should handle disconnect and log it', async () => {
     const consoleSpy = jest.spyOn(console, 'log').mockImplementation(() => {});

--- a/src/utils/socket.ts
+++ b/src/utils/socket.ts
@@ -9,6 +9,7 @@ import { decryptMessage } from './decryptMessage';
 import { addNewMessageInRealm } from '../realm-database/operations/addNewMessage';
 import { updateMessageStatusInRealm } from '../realm-database/operations/updateMessageStatus';
 import { getRealmInstance } from '../realm-database/connection';
+import { updateUserAccountStatusInRealm } from '../realm-database/operations/updateUserAccountStatus';
 
 let socket: Socket<DefaultEventsMap, DefaultEventsMap> | null = null;
 
@@ -59,6 +60,12 @@ export const socketConnection = async (mobileNumber: string) => {
         const { sentAt, chatId, status, updatedCount, messageIds } = data;
         updateMessageStatusInRealm( {chatId: chatId, sentAt: sentAt, messageIds: messageIds, status: status, updateAllBeforeSentAt: updatedCount > 1});
       });
+
+      socket.on('isAccountDeleted', data => {
+        const { isAccountDeleted, chatId} = data;
+        updateUserAccountStatusInRealm(chatId, isAccountDeleted);
+      });
+
       socket.on('force-logout', () => {
         store.dispatch(clearSuccessMessage());
       });


### PR DESCRIPTION
### 📌 What does this PR do?
- This PR adds emitting a socket event when user opens individual chat screen to check whether the other user of the chat has deleted their account. 
- Updates the status in local db and disables the input box in chat screen and displays a message that `This user has deleted their account`.

### 🧪 Testing
- All the components, screens and functions updated and added were unit tested with Jest and RNTL.
- Everything is working as expected.

Thank you 😊.