### PR TITLE
Fix android - media permission

### DIFF
--- a/src/permissions/permissions.test.ts
+++ b/src/permissions/permissions.test.ts
@@ -150,4 +150,12 @@ describe('Tests related to the requestNotificationPermissions method', () => {
     const result = await requestNotificationPermissions();
     expect(result).toBe(false);
   });
+  it('should grant send-sms permission in android', async () => {
+    (Platform as any).OS = 'android';
+    (Platform as any).select = (obj: any) => obj.android;
+    (RNPermissions.check as jest.Mock).mockResolvedValue('denied');
+    (RNPermissions.request as jest.Mock).mockResolvedValue('granted');
+    const result = await requestPermission('send-sms');
+    expect(result).toBe(true);
+  });
 });

--- a/src/permissions/permissions.test.ts
+++ b/src/permissions/permissions.test.ts
@@ -172,4 +172,24 @@ describe('Tests related to the requestNotificationPermissions method', () => {
     const result = await requestPermission('send-sms');
     expect(result).toBe(true);
   });
+  it('should throw an error when exception occurs in permission', async () => {
+    (Platform as any).OS = 'android';
+    (Platform as any).select = (obj: any) => obj.android;
+    (RNPermissions.check as jest.Mock).mockRejectedValue(
+      new Error('Mock failure'),
+    );
+    await expect(requestPermission('camera')).rejects.toThrow(
+      'Something went wrong!',
+    );
+  });
+   it('should throw an error when exception occurs in requestNotifications permission', async () => {
+    (Platform as any).OS = 'android';
+    (Platform as any).select = (obj: any) => obj.android;
+    (PermissionsAndroid.check as jest.Mock).mockRejectedValue(
+      new Error('Mock android error'),
+    );
+    await expect(requestNotificationPermissions()).rejects.toThrow(
+      'Unable to ask permissions',
+    );
+  });
 });

--- a/src/permissions/permissions.test.ts
+++ b/src/permissions/permissions.test.ts
@@ -1,6 +1,6 @@
-import { PermissionsAndroid, Platform } from 'react-native';
+import {PermissionsAndroid, Platform} from 'react-native';
 import * as RNPermissions from 'react-native-permissions';
-import { requestNotificationPermissions, requestPermission } from './permissions';
+import {requestNotificationPermissions, requestPermission} from './permissions';
 
 jest.mock('react-native', () => ({
   Platform: {
@@ -64,6 +64,7 @@ describe('Tests related to the requestPermission method', () => {
   it('Should denies the media permission on Android', async () => {
     (Platform as any).OS = 'android';
     (Platform as any).select = (obj: any) => obj.android;
+    (Platform as any).Version = 33;
     (RNPermissions.check as jest.Mock).mockResolvedValue('denied');
     (RNPermissions.request as jest.Mock).mockResolvedValue('denied');
     const result = await requestPermission('media');
@@ -91,8 +92,12 @@ describe('Tests related to the requestNotificationPermissions method', () => {
   it('Should grants notification permission on iOS after requesting', async () => {
     (Platform as any).OS = 'ios';
     (Platform as any).select = (obj: any) => obj.ios;
-    (RNPermissions.checkNotifications as jest.Mock).mockResolvedValue({ status: 'denied' });
-    (RNPermissions.requestNotifications as jest.Mock).mockResolvedValue({ status: 'granted' });
+    (RNPermissions.checkNotifications as jest.Mock).mockResolvedValue({
+      status: 'denied',
+    });
+    (RNPermissions.requestNotifications as jest.Mock).mockResolvedValue({
+      status: 'granted',
+    });
     const result = await requestNotificationPermissions();
     expect(result).toBe(true);
   });
@@ -100,7 +105,9 @@ describe('Tests related to the requestNotificationPermissions method', () => {
   it('Should returns true if notification already granted on iOS', async () => {
     (Platform as any).OS = 'ios';
     (Platform as any).select = (obj: any) => obj.ios;
-    (RNPermissions.checkNotifications as jest.Mock).mockResolvedValue({ status: 'granted' });
+    (RNPermissions.checkNotifications as jest.Mock).mockResolvedValue({
+      status: 'granted',
+    });
     const result = await requestNotificationPermissions();
     expect(result).toBe(true);
   });
@@ -108,8 +115,12 @@ describe('Tests related to the requestNotificationPermissions method', () => {
   it('Should returns false if notification denied on iOS', async () => {
     (Platform as any).OS = 'ios';
     (Platform as any).select = (obj: any) => obj.ios;
-    (RNPermissions.checkNotifications as jest.Mock).mockResolvedValue({ status: 'denied' });
-    (RNPermissions.requestNotifications as jest.Mock).mockResolvedValue({ status: 'blocked' });
+    (RNPermissions.checkNotifications as jest.Mock).mockResolvedValue({
+      status: 'denied',
+    });
+    (RNPermissions.requestNotifications as jest.Mock).mockResolvedValue({
+      status: 'blocked',
+    });
     const result = await requestNotificationPermissions();
     expect(result).toBe(false);
   });

--- a/src/permissions/permissions.test.ts
+++ b/src/permissions/permissions.test.ts
@@ -158,4 +158,18 @@ describe('Tests related to the requestNotificationPermissions method', () => {
     const result = await requestPermission('send-sms');
     expect(result).toBe(true);
   });
+  it('should deny send-sms permission in android', async () => {
+    (Platform as any).OS = 'android';
+    (Platform as any).select = (obj: any) => obj.android;
+    (RNPermissions.check as jest.Mock).mockResolvedValue('denied');
+    (RNPermissions.request as jest.Mock).mockResolvedValue('denied');
+    const result = await requestPermission('send-sms');
+    expect(result).toBe(false);
+  });
+  it('should return true when permission undefined', async () => {
+    (Platform as any).OS = 'ios';
+    (Platform as any).select = (obj: any) => obj.ios;
+    const result = await requestPermission('send-sms');
+    expect(result).toBe(true);
+  });
 });

--- a/src/permissions/permissions.test.ts
+++ b/src/permissions/permissions.test.ts
@@ -182,7 +182,7 @@ describe('Tests related to the requestNotificationPermissions method', () => {
       'Something went wrong!',
     );
   });
-   it('should throw an error when exception occurs in requestNotifications permission', async () => {
+  it('should throw an error when exception occurs in requestNotifications permission', async () => {
     (Platform as any).OS = 'android';
     (Platform as any).select = (obj: any) => obj.android;
     (PermissionsAndroid.check as jest.Mock).mockRejectedValue(
@@ -191,5 +191,12 @@ describe('Tests related to the requestNotificationPermissions method', () => {
     await expect(requestNotificationPermissions()).rejects.toThrow(
       'Unable to ask permissions',
     );
+  });
+  it('should return false if permission is blocked', async () => {
+    (Platform as any).OS = 'android';
+    (Platform as any).select = (obj: any) => obj.android;
+    (RNPermissions.check as jest.Mock).mockResolvedValue('blocked');
+    const result = await requestPermission('camera');
+    expect(result).toBe(false);
   });
 });

--- a/src/permissions/permissions.ts
+++ b/src/permissions/permissions.ts
@@ -1,5 +1,12 @@
 import {PermissionsAndroid, Platform} from 'react-native';
-import {check, checkNotifications, PERMISSIONS, request, requestNotifications, RESULTS} from 'react-native-permissions';
+import {
+  check,
+  checkNotifications,
+  PERMISSIONS,
+  request,
+  requestNotifications,
+  RESULTS,
+} from 'react-native-permissions';
 
 const requestPermission = async (permissionType: string) => {
   try {
@@ -14,7 +21,10 @@ const requestPermission = async (permissionType: string) => {
       case 'media':
         permission = Platform.select({
           ios: PERMISSIONS.IOS.PHOTO_LIBRARY,
-          android: PERMISSIONS.ANDROID.READ_MEDIA_IMAGES,
+          android:
+            Number(Platform.Version) >= 33
+              ? PERMISSIONS.ANDROID.READ_MEDIA_IMAGES
+              : PERMISSIONS.ANDROID.READ_EXTERNAL_STORAGE,
         });
         break;
       case 'contacts':
@@ -51,25 +61,33 @@ const requestPermission = async (permissionType: string) => {
   }
 };
 
-export const requestNotificationPermissions = async() => {
-  try{
-    if(Platform.OS === 'android') {
-      const isPermisssinGranted = await PermissionsAndroid.check(PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS);
+export const requestNotificationPermissions = async () => {
+  try {
+    if (Platform.OS === 'android') {
+      const isPermisssinGranted = await PermissionsAndroid.check(
+        PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS,
+      );
       console.log('permission status: ', isPermisssinGranted);
-      if(!isPermisssinGranted) {
-        const status = await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS);
+      if (!isPermisssinGranted) {
+        const status = await PermissionsAndroid.request(
+          PermissionsAndroid.PERMISSIONS.POST_NOTIFICATIONS,
+        );
         return status === 'granted' ? true : false;
       }
       return true;
-    } else if(Platform.OS === 'ios') {
-      const { status: currentStatus } = await checkNotifications();
+    } else if (Platform.OS === 'ios') {
+      const {status: currentStatus} = await checkNotifications();
       if (currentStatus === 'granted') {
         return true;
       }
-      const { status: newStatus } = await requestNotifications(['alert', 'sound', 'badge']);
+      const {status: newStatus} = await requestNotifications([
+        'alert',
+        'sound',
+        'badge',
+      ]);
       return newStatus === 'granted' ? true : false;
     }
-  } catch(error) {
+  } catch (error) {
     throw new Error('Unable to ask permissions');
   }
 };


### PR DESCRIPTION
## What does this PR do:
- This PR implements the enable media permissions in all android versions.
- Improved test coverage for permissions.
- All utils updated in this PR are unit tested using Jest+RNTL and everything is working as expected.

Thank you!