### PR TITLE
Implement changePasswordModal

### DIFF
--- a/src/components/ChangePasswordModal/ChangePasswordModal.styles.ts
+++ b/src/components/ChangePasswordModal/ChangePasswordModal.styles.ts
@@ -1,0 +1,73 @@
+import { StyleSheet } from 'react-native';
+import { Theme } from '../../utils/themes';
+
+export const getStyles = (theme: Theme, width: number, height: number) => StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.4)',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  modal: {
+    backgroundColor: theme.changePasswordModalBackground,
+    padding: height > 900 ? 24 : 20,
+    borderRadius: 12,
+    width: width > 600 ?  '70%' : '84%',
+    elevation: 10,
+    gap: 8,
+  },
+  title: {
+    fontSize: 20,
+    marginBottom: 12,
+    textAlign: 'center',
+    color : theme.changePasswordModalTitleColor,
+    fontFamily: 'Nunito-Bold',
+  },
+  input: {
+    borderBottomWidth: 1,
+    borderBottomColor: '#008080',
+    borderRadius: 8,
+    padding: height > 900 ? 8 : 8,
+    marginBottom: 10,
+    fontFamily: 'Nunito-Regular',
+    color: theme.ChangePasswordModalInputColor,
+  },
+  error: {
+    color: theme.primaryErrorText,
+    marginBottom: 1,
+    paddingLeft:5,
+    fontFamily: 'Nunito-Regular',
+
+  },
+  allFields: {
+    color: theme.primaryErrorText,
+    marginBottom: 8,
+    textAlign: 'center',
+    fontFamily: 'Nunito-Regular',
+  },
+  buttonContainer: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    gap: 10,
+  },
+  cancelButton: {
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    borderRadius: 6,
+    backgroundColor: '#ccc',
+  },
+  cancelText: {
+    color: '#333',
+    fontFamily: 'Nunito-Bold',
+  },
+  saveButton: {
+    paddingVertical: 10,
+    paddingHorizontal: 16,
+    borderRadius: 6,
+    backgroundColor: '#008080',
+  },
+  saveText: {
+    color: '#fff',
+    fontFamily: 'Nunito-Bold',
+  },
+});

--- a/src/components/ChangePasswordModal/ChangePasswordModal.test.tsx
+++ b/src/components/ChangePasswordModal/ChangePasswordModal.test.tsx
@@ -1,0 +1,322 @@
+import React from 'react';
+import EncryptedStorage from 'react-native-encrypted-storage';
+import { Provider } from 'react-redux';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { store } from '../../redux/store';
+import * as profileService from '../../screens/Profile/Profile.services';
+import * as tokens from '../../utils/getTokens';
+import { ChangePasswordModal } from './ChangePasswordModal';
+
+jest.mock('../../utils/getTokens');
+jest.mock('../../screens/Profile/Profile.services');
+
+jest.mock('react-native-encrypted-storage', () => ({
+  setItem: jest.fn(),
+  clear: jest.fn(),
+}));
+
+const mockResetRealm = jest.fn();
+jest.mock('../../contexts/RealmContext', () => ({
+  useRealmReset: () => ({
+    resetRealm: mockResetRealm,
+  }),
+}));
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: () => mockUser,
+  useDispatch: () => mockDispatch,
+}));
+
+const mockShowAlert = jest.fn();
+jest.mock('../../hooks/useAlertModal', () => {
+  return {
+    useAlertModal: () => ({
+      alertVisible: false,
+      alertMessage: '',
+      alertType: '',
+      showAlert: mockShowAlert,
+      hideAlert: jest.fn(),
+    }),
+  };
+});
+
+const mockDispatch = jest.fn();
+const mockUser = {
+  firstName: 'Mamatha',
+  email: 'mamatha@gmail.com',
+  mobileNumber: '+91 63039 74914',
+};
+
+describe(' Check for ChangePasswordModal', () => {
+  const onClose = jest.fn();
+
+  const renderChangePasswordModal = () =>
+    render(
+      <Provider store={store}>
+        <ChangePasswordModal visible={true} onClose={onClose} />,
+      </Provider>,
+    );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('Should render all the fields correctly', () => {
+    const {getByPlaceholderText, getByText} = renderChangePasswordModal();
+
+    expect(getByText('Change Password')).toBeTruthy();
+    expect(getByPlaceholderText('Old Password')).toBeTruthy();
+    expect(getByPlaceholderText('New Password')).toBeTruthy();
+    expect(getByPlaceholderText('Confirm Password')).toBeTruthy();
+  });
+  it('Should show all fields required error if all fields are empty', () => {
+    const {getByText} = renderChangePasswordModal();
+    const saveBtn = getByText('Save');
+    fireEvent.press(saveBtn);
+    expect(getByText('All fields are required')).toBeTruthy();
+  });
+  it('Should show error for new password when it does not match the conditions', () => {
+    const {getByPlaceholderText, getByText, queryByText} =
+      renderChangePasswordModal();
+    fireEvent.changeText(getByPlaceholderText('Old Password'), 'Mamatha@123');
+    fireEvent.changeText(getByPlaceholderText('New Password'), '12');
+    fireEvent.changeText(getByPlaceholderText('Confirm Password'), '12');
+
+    fireEvent.press(getByText('Save'));
+
+    expect(
+      getByText(
+        'Must be at least 8 characters, include uppercase, lowercase, number, and at least one special character',
+      ),
+    ).toBeTruthy();
+    expect(queryByText('Passwords do not match')).toBeNull();
+  });
+  it('Should show error only for old password when it is missing', () => {
+    const {getByPlaceholderText, getByText} = renderChangePasswordModal();
+    fireEvent.changeText(getByPlaceholderText('New Password'), 'Mamtha@12');
+    fireEvent.changeText(
+      getByPlaceholderText('Confirm Password'),
+      'Mamatha@12',
+    );
+    fireEvent.press(getByText('Save'));
+
+    expect(getByText('Old password is required')).toBeTruthy();
+  });
+  it('Should show mismatch error when passwords don’t match', () => {
+    const {getByPlaceholderText, getByText} = renderChangePasswordModal();
+    fireEvent.changeText(getByPlaceholderText('Old Password'), 'Mamatha@123');
+    fireEvent.changeText(getByPlaceholderText('New Password'), 'Mamatha@12');
+    fireEvent.changeText(getByPlaceholderText('Confirm Password'), '12');
+
+    fireEvent.press(getByText('Save'));
+
+    expect(getByText('Passwords do not match')).toBeTruthy();
+  });
+  it('Should clear old password error when user starts typing', () => {
+    const {getByPlaceholderText, getByText, queryByText} =
+      renderChangePasswordModal();
+
+    fireEvent.changeText(getByPlaceholderText('New Password'), 'Mamatha@12');
+    fireEvent.changeText(
+      getByPlaceholderText('Confirm Password'),
+      'Mamatha@12',
+    );
+
+    fireEvent.press(getByText('Save'));
+
+    expect(getByText('Old password is required')).toBeTruthy();
+
+    fireEvent.changeText(getByPlaceholderText('Old Password'), 'Mamatha@123');
+
+    expect(queryByText('Old password is required')).toBeNull();
+  });
+  it('Should clear new password error when user starts typing', () => {
+    const {getByPlaceholderText, getByText, queryByText} =
+      renderChangePasswordModal();
+
+    fireEvent.changeText(getByPlaceholderText('Old Password'), 'Mamatha@123');
+    fireEvent.changeText(
+      getByPlaceholderText('Confirm Password'),
+      'Mamatha@12',
+    );
+
+    fireEvent.press(getByText('Save'));
+
+    expect(getByText('New password is required')).toBeTruthy();
+
+    fireEvent.changeText(getByPlaceholderText('New Password'), 'Mamatha@12');
+
+    expect(queryByText('New password is required')).toBeNull();
+  });
+  it('Should clear confirm password error when user starts typing', () => {
+    const {getByPlaceholderText, getByText, queryByText} =
+      renderChangePasswordModal();
+
+    fireEvent.changeText(getByPlaceholderText('Old Password'), 'Mamatha@123');
+    fireEvent.changeText(getByPlaceholderText('New Password'), 'Mamatha@12');
+
+    fireEvent.press(getByText('Save'));
+
+    expect(getByText('Please confirm your password')).toBeTruthy();
+
+    fireEvent.changeText(
+      getByPlaceholderText('Confirm Password'),
+      'Mamatha@12',
+    );
+
+    expect(queryByText('Please confirm your password')).toBeNull();
+  });
+  it('Shoudl clear inputs and errors when cancel is pressed', () => {
+    const {getByText, getByPlaceholderText} = renderChangePasswordModal();
+
+    fireEvent.changeText(getByPlaceholderText('Old Password'), 'Mamatha@123');
+    fireEvent.changeText(getByPlaceholderText('New Password'), 'Mamatha@12');
+    fireEvent.changeText(
+      getByPlaceholderText('Confirm Password'),
+      'Mamatha@12',
+    );
+
+    fireEvent.press(getByText('Cancel'));
+
+    expect(onClose).toHaveBeenCalled();
+  });
+  it('Should clear storage and reset realm if getTokens returns null', async () => {
+    (tokens.getTokens as jest.Mock).mockResolvedValue(null);
+
+    const {getByPlaceholderText, getByText} = renderChangePasswordModal();
+
+    fireEvent.changeText(getByPlaceholderText('Old Password'), 'Old@1234');
+    fireEvent.changeText(getByPlaceholderText('New Password'), 'New@1234');
+    fireEvent.changeText(getByPlaceholderText('Confirm Password'), 'New@1234');
+
+    fireEvent.press(getByText('Save'));
+
+    await waitFor(() => {
+      expect(EncryptedStorage.clear).toHaveBeenCalled();
+      expect(mockResetRealm).toHaveBeenCalled();
+    });
+  });
+  it('Should call updatePassword API and show success alert', async () => {
+    jest.spyOn(tokens, 'getTokens').mockResolvedValue({access_token: 'token'});
+    jest.spyOn(profileService, 'updatePassword').mockResolvedValue(
+      new Response(JSON.stringify({}), {
+        status: 200,
+        statusText: 'OK',
+        headers: {'Content-Type': 'application/json'},
+      }),
+    );
+
+    const {getByPlaceholderText, getByText} = renderChangePasswordModal();
+
+    fireEvent.changeText(getByPlaceholderText('Old Password'), 'Mamatha@123');
+    fireEvent.changeText(getByPlaceholderText('New Password'), 'Mamatha@12');
+    fireEvent.changeText(
+      getByPlaceholderText('Confirm Password'),
+      'Mamatha@12',
+    );
+
+    fireEvent.press(getByText('Save'));
+
+    await waitFor(() => {
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+  it('Should show error alert if API returns 401', async () => {
+    jest.spyOn(tokens, 'getTokens').mockResolvedValue({access_token: 'token'});
+
+    jest.spyOn(profileService, 'updatePassword').mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({}),
+    } as unknown as Response);
+
+    const {getByPlaceholderText, getByText} = renderChangePasswordModal();
+
+    fireEvent.changeText(getByPlaceholderText('Old Password'), 'wrongpass');
+    fireEvent.changeText(getByPlaceholderText('New Password'), 'Mamatha@12');
+    fireEvent.changeText(
+      getByPlaceholderText('Confirm Password'),
+      'Mamatha@12',
+    );
+
+    fireEvent.press(getByText('Save'));
+
+    await waitFor(() => {
+      expect(mockShowAlert).toHaveBeenCalledWith(
+        'Old password is incorrect',
+        'error',
+      );
+    });
+  });
+  it('Should show info alert if old and new password are same', async () => {
+    const mockUpdatePassword = jest.spyOn(profileService, 'updatePassword');
+    mockUpdatePassword.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      json: async () => ({message: 'Please give a different value'}),
+    } as unknown as Response);
+
+    const {getByPlaceholderText, getByText} = renderChangePasswordModal();
+
+    fireEvent.changeText(getByPlaceholderText('Old Password'), 'Same@123');
+    fireEvent.changeText(getByPlaceholderText('New Password'), 'Same@123');
+    fireEvent.changeText(getByPlaceholderText('Confirm Password'), 'Same@123');
+
+    fireEvent.press(getByText('Save'));
+
+    await waitFor(() => {
+      expect(mockShowAlert).toHaveBeenCalledWith(
+        'Please give a different value',
+        'info',
+      );
+    });
+  });
+  it('Should show default error message if no message in response', async () => {
+    const mockUpdatePassword = jest.spyOn(profileService, 'updatePassword');
+    mockUpdatePassword.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    } as unknown as Response);
+
+    const {getByPlaceholderText, getByText} = renderChangePasswordModal();
+
+    fireEvent.changeText(getByPlaceholderText('Old Password'), 'Old@1234');
+    fireEvent.changeText(getByPlaceholderText('New Password'), 'New@1234');
+    fireEvent.changeText(getByPlaceholderText('Confirm Password'), 'New@1234');
+
+    fireEvent.press(getByText('Save'));
+
+    await waitFor(() => {
+      expect(mockShowAlert).toHaveBeenCalledWith(
+        'Failed to update password',
+        'error',
+      );
+    });
+  });
+  it('Should show error alert if updatePassword throws an error', async () => {
+    jest.spyOn(tokens, 'getTokens').mockResolvedValue({access_token: 'token'});
+    jest
+      .spyOn(profileService, 'updatePassword')
+      .mockRejectedValue(new Error('Network error'));
+
+    const {getByPlaceholderText, getByText} = renderChangePasswordModal();
+
+    fireEvent.changeText(getByPlaceholderText('Old Password'), 'Mamatha@123');
+    fireEvent.changeText(getByPlaceholderText('New Password'), 'Mamatha@12');
+    fireEvent.changeText(
+      getByPlaceholderText('Confirm Password'),
+      'Mamatha@12',
+    );
+
+    fireEvent.press(getByText('Save'));
+
+    await waitFor(() => {
+      expect(mockShowAlert).toHaveBeenCalledWith(
+        'Something went wrong',
+        'error',
+      );
+    });
+  });
+});

--- a/src/components/ChangePasswordModal/ChangePasswordModal.tsx
+++ b/src/components/ChangePasswordModal/ChangePasswordModal.tsx
@@ -1,0 +1,231 @@
+import React, { useState } from 'react';
+import { Modal, Text, TextInput, TouchableOpacity, useWindowDimensions, View } from 'react-native';
+import EncryptedStorage from 'react-native-encrypted-storage';
+import { useSelector } from 'react-redux';
+import { useRealmReset } from '../../contexts/RealmContext';
+import { useAppTheme } from '../../hooks/appTheme';
+import { useAlertModal } from '../../hooks/useAlertModal';
+import { storeState } from '../../redux/store';
+import { updatePassword } from '../../screens/Profile/Profile.services';
+import { getTokens } from '../../utils/getTokens';
+import { Theme } from '../../utils/themes';
+import { CustomAlert } from '../CustomAlert/CustomAlert';
+import { getStyles } from './ChangePasswordModal.styles';
+
+interface ChangePasswordModalProps {
+  visible: boolean;
+  onClose: () => void;
+}
+
+export const ChangePasswordModal: React.FC<ChangePasswordModalProps> = ({
+  visible,
+  onClose,
+}) => {
+
+  const { width, height } = useWindowDimensions();
+  const theme: Theme = useAppTheme();
+  const styles = getStyles(theme, width, height);
+
+  const [oldPassword, setOldPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [errors, setErrors] = useState<{
+    oldPassword?: string;
+    newPassword?: string;
+    confirmPassword?: string;
+    allFields?: string;
+  }>({});
+  const {alertVisible, alertMessage, alertType, showAlert, hideAlert} = useAlertModal();
+  const {resetRealm} = useRealmReset();
+
+  const userDetails = useSelector((state: storeState) => state.user);
+
+  const handleSave = async () => {
+    const newErrors: typeof errors = {};
+
+    const allFieldsEmpty =
+      !oldPassword.trim() && !newPassword.trim() && !confirmPassword.trim();
+
+    if (allFieldsEmpty) {
+      setErrors({
+        oldPassword: '',
+        newPassword: '',
+        confirmPassword: '',
+        allFields: 'All fields are required',
+      });
+      return;
+    }
+
+    if (!oldPassword) {
+      newErrors.oldPassword = 'Old password is required';
+    }
+    if (!newPassword) {
+      newErrors.newPassword = 'New password is required';
+    } else {
+      const passwordRegex =
+        /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/;
+      if (!passwordRegex.test(newPassword)) {
+        newErrors.newPassword =
+          'Must be at least 8 characters, include uppercase, lowercase, number, and at least one special character';
+      }
+    }
+    if (!newErrors.newPassword) {
+      if (!confirmPassword) {
+        newErrors.confirmPassword = 'Please confirm your password';
+      } else if (newPassword !== confirmPassword) {
+        newErrors.confirmPassword = 'Passwords do not match';
+      }
+    }
+
+    setErrors(newErrors);
+
+    if (Object.keys(newErrors).length > 0) {
+      return;
+    }
+
+    onClose();
+    setOldPassword('');
+    setNewPassword('');
+    setConfirmPassword('');
+    setErrors({});
+
+    try {
+      const tokens = await getTokens(userDetails.mobileNumber);
+      if (!tokens) {
+        await EncryptedStorage.clear();
+        resetRealm();
+        return;
+      }
+      const response = await updatePassword(
+        userDetails.mobileNumber,
+        oldPassword,
+        newPassword,
+        tokens.access_token,
+      );
+
+      if (response.ok) {
+        showAlert('Updated password successfully', 'success');
+        onClose();
+        handleClose();
+      } else if (response.status === 400) {
+        showAlert('Please give a different value', 'info');
+      } else if (response.status === 401) {
+        showAlert('Old password is incorrect', 'error');
+      } else {
+        const result = await response.json();
+        showAlert(result.message || 'Failed to update password', 'error');
+      }
+    } catch (error) {
+      showAlert('Something went wrong', 'error');
+    }
+  };
+
+  const handleClose = () => {
+    setErrors({});
+    setOldPassword('');
+    setNewPassword('');
+    setConfirmPassword('');
+    onClose();
+  };
+
+  return (
+    <>
+      <Modal
+      accessibilityLabel="change-password-modal"
+        animationType="fade"
+        transparent
+        visible={visible}
+        onRequestClose={handleClose}>
+        <View style={styles.overlay}>
+          <View style={styles.modal}>
+            <Text style={styles.title}>Change Password</Text>
+            {errors.allFields ? (
+              <Text style={styles.allFields}>{errors.allFields}</Text>
+            ) : null}
+
+            <TextInput
+              placeholder="Old Password"
+              placeholderTextColor={theme.changePasswordModalPlaceholderColor}
+              style={styles.input}
+              secureTextEntry
+              value={oldPassword}
+              onChangeText={text => {
+                setOldPassword(text);
+                if (errors.oldPassword || errors.allFields) {
+                  setErrors(prev => ({
+                    ...prev,
+                    oldPassword: '',
+                    allFields: '',
+                  }));
+                }
+              }}
+            />
+            {errors.oldPassword && (
+              <Text style={styles.error}>{errors.oldPassword}</Text>
+            )}
+
+            <TextInput
+              placeholder="New Password"
+              placeholderTextColor={theme.changePasswordModalPlaceholderColor}
+              style={styles.input}
+              secureTextEntry
+              value={newPassword}
+              onChangeText={text => {
+                setNewPassword(text);
+                if (errors.newPassword || errors.allFields) {
+                  setErrors(prev => ({
+                    ...prev,
+                    newPassword: '',
+                    allFields: '',
+                  }));
+                }
+              }}
+            />
+            {errors.newPassword && (
+              <Text style={styles.error}>{errors.newPassword}</Text>
+            )}
+
+            <TextInput
+              placeholder="Confirm Password"
+              placeholderTextColor={theme.changePasswordModalPlaceholderColor}
+              style={styles.input}
+              secureTextEntry
+              value={confirmPassword}
+              onChangeText={text => {
+                setConfirmPassword(text);
+                if (errors.confirmPassword || errors.allFields) {
+                  setErrors(prev => ({
+                    ...prev,
+                    confirmPassword: '',
+                    allFields: '',
+                  }));
+                }
+              }}
+            />
+
+            {errors.confirmPassword && (
+              <Text style={styles.error}>{errors.confirmPassword}</Text>
+            )}
+            <View style={styles.buttonContainer}>
+              <TouchableOpacity
+                style={styles.cancelButton}
+                onPress={handleClose}>
+                <Text style={styles.cancelText}>Cancel</Text>
+              </TouchableOpacity>
+
+              <TouchableOpacity style={styles.saveButton} onPress={handleSave}>
+                <Text style={styles.saveText}>Save</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      </Modal>
+      <CustomAlert
+        visible={alertVisible}
+        message={alertMessage}
+        type={alertType}
+        onClose={hideAlert}
+      />
+    </>
+  );
+};

--- a/src/components/ProfileInfoTile/ProfileInfoTile.test.tsx
+++ b/src/components/ProfileInfoTile/ProfileInfoTile.test.tsx
@@ -1,7 +1,7 @@
-import EncryptedStorage from 'react-native-encrypted-storage';
-import { Provider } from 'react-redux';
 import { NavigationContainer, useNavigation } from '@react-navigation/native';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import EncryptedStorage from 'react-native-encrypted-storage';
+import { Provider } from 'react-redux';
 import { setUserProperty } from '../../redux/reducers/user.reducer';
 import { store } from '../../redux/store';
 import * as ProfileServices from '../../screens/Profile/Profile.services';
@@ -121,23 +121,6 @@ describe('Tests related to the Profile Info Tile component', () => {
             );
             expect(EncryptedStorage.setItem).toHaveBeenCalled();
             expect(screen.getByText('Updated first name successfully')).toBeTruthy();
-        });
-    });
-
-    it('Should update password, dispatch action, set encrypted storage on success and show alert', async () => {
-        (tokenUtil.getTokens as jest.Mock).mockResolvedValue({ access_token: 'access-token' });
-        (ProfileServices.updateProfileDetails as jest.Mock).mockResolvedValue({ ok: true });
-        renderUI('Change Password', 'Varun', 'Change Password');
-        const passwordValue = screen.getByPlaceholderText('Varun');
-        fireEvent.changeText(passwordValue, 'Virat');
-        fireEvent.press(screen.getByLabelText('edit'));
-        await waitFor(() => {
-            expect(mockDispatch).toHaveBeenCalledWith(
-                setUserProperty({ property: 'password', value: 'Virat' })
-            );
-            expect(EncryptedStorage.setItem).toHaveBeenCalled();
-            expect(screen.getByText('Updated password successfully')).toBeTruthy();
-
         });
     });
     it('Should not update the user details if response is not ok', async () => {

--- a/src/components/ProfileInfoTile/ProfileInfoTile.tsx
+++ b/src/components/ProfileInfoTile/ProfileInfoTile.tsx
@@ -21,7 +21,7 @@ interface ProfileInfoTileProps {
   editField: string;
   setEditField: React.Dispatch<React.SetStateAction<string>>;
   setLoading: React.Dispatch<React.SetStateAction<boolean>>;
-}
+  onPress?: () => void;}
 
 export const ProfileInfoTile = (props: ProfileInfoTileProps) => {
 
@@ -36,6 +36,16 @@ export const ProfileInfoTile = (props: ProfileInfoTileProps) => {
   const isEdit = props.editField === props.label;
   const setLoading = props.setLoading;
   const {resetRealm} = useRealmReset();
+
+  const handleEdit = (label: string) =>{
+    if(label !== 'Change Password') {
+      props.setEditField(label);
+      setValue('');
+    }
+    if(label === 'Change Password' && props.onPress) {
+      props.onPress();
+    }
+  };
 
   const updateDetails = async() => {
     if(!newValue.trim() || newValue.trim() === props.value) {
@@ -79,11 +89,8 @@ export const ProfileInfoTile = (props: ProfileInfoTileProps) => {
           'User Data',
           JSON.stringify(updatedUser),
         );
-        if(props.label === 'Change Password') {
-          showAlert('Updated password successfully', 'success');
-        } else {
-          showAlert(`Updated ${props.label.toLowerCase()} successfully`, 'success');
-        }
+        showAlert(`Updated ${props.label.toLowerCase()} successfully`, 'success');
+
       }
       props.setEditField('');
     } catch (error) {
@@ -104,18 +111,23 @@ export const ProfileInfoTile = (props: ProfileInfoTileProps) => {
       <View style={styles.fieldBox}>
         <View style={styles.detailBox}>
           <Text style={styles.headerText}>{props.label}</Text>
-          {!isEdit ? (
+          {!isEdit &&
+          (
             <Text
               style={styles.valueText}
               ellipsizeMode="tail"
               numberOfLines={1}>
               {props.value}
             </Text>
-          ) : (
+          )}
+          { isEdit && props.label !== 'Change Password' && (
             <View style={styles.editTileBox}>
               <TextInput
                 value={newValue}
                 onChangeText={value => {
+                  if(props.label === 'Email'){
+                    value = value.trim().toLowerCase();
+                  }
                   setValue(value);
                 }}
                 placeholder={props.value}
@@ -152,10 +164,7 @@ export const ProfileInfoTile = (props: ProfileInfoTileProps) => {
         </View>
         {props.label !== 'Contact' && !isEdit && (
           <TouchableOpacity
-            onPress={() => {
-              props.setEditField(props.label);
-              setValue('');
-            }}>
+            onPress={()=>handleEdit(props.label)}>
             <Image
               source={require('../../../assets/icons/edit-text-icon.png')}
               style={styles.editTextIcon}

--- a/src/screens/Profile/Profile.services.test.ts
+++ b/src/screens/Profile/Profile.services.test.ts
@@ -1,4 +1,4 @@
-import { deleteAccount, logout, removeProfilePic, updateProfileDetails, updateProfilePic } from './Profile.services';
+import { deleteAccount, logout, removeProfilePic, updatePassword, updateProfileDetails, updateProfilePic } from './Profile.services';
 
 global.fetch = jest.fn();
 
@@ -8,15 +8,22 @@ describe('Tests related to Profile screen handlers', () => {
         jest.resetAllMocks();
     });
 
-    it('should call fetch when updateProfileDetails method invokes', async () => {
+    it('Should call fetch when updateProfileDetails method invokes', async () => {
         (global.fetch as jest.Mock).mockResolvedValue({
             ok: true,
         });
         await updateProfileDetails('firstName', 'Varun', '9392990600', 'sample-access-token');
         expect(fetch).toHaveBeenCalled();
     });
+    it('Should call fetch when updatepassword method invokes', async() =>{
+        (global.fetch as jest.Mock).mockResolvedValue({
+            ok: true,
+        });
+        await updatePassword('+91 63039 74914', 'Mamatha@123', 'Mamatha@12', 'sample-access-token');
+        expect(fetch).toHaveBeenCalled();
+    });
 
-    it('should call fetch when removeProfilePic method invokes', async () => {
+    it('Should call fetch when removeProfilePic method invokes', async () => {
         (global.fetch as jest.Mock).mockResolvedValue({
             ok: true,
         });
@@ -24,7 +31,7 @@ describe('Tests related to Profile screen handlers', () => {
         expect(fetch).toHaveBeenCalled();
     });
 
-    it('should call fetch when deleteAccount method invokes', async () => {
+    it('Should call fetch when deleteAccount method invokes', async () => {
         (global.fetch as jest.Mock).mockResolvedValue({
             ok: true,
         });
@@ -32,7 +39,7 @@ describe('Tests related to Profile screen handlers', () => {
         expect(fetch).toHaveBeenCalled();
     });
 
-    it('should call fetch when updated method invokes', async () => {
+    it('Should call fetch when updated method invokes', async () => {
         (global.fetch as jest.Mock).mockResolvedValue({
             ok: true,
         });

--- a/src/screens/Profile/Profile.services.ts
+++ b/src/screens/Profile/Profile.services.ts
@@ -1,71 +1,104 @@
-import { BASE_URL } from '../../utils/constants';
+import {BASE_URL} from '../../utils/constants';
 
-export const deleteAccount = async(mobileNumber: string, accessToken: string) => {
-    const response = await fetch(`${BASE_URL}user`, {
-        method: 'DELETE',
-        headers: {
-            'Content-Type': 'application/json',
-            'smart-chat-token-header-key': `Bearer ${accessToken}`,
-        },
-        body: JSON.stringify({
-            mobileNumber: mobileNumber,
-        }),
-    });
-    return response;
+export const deleteAccount = async (
+  mobileNumber: string,
+  accessToken: string,
+) => {
+  const response = await fetch(`${BASE_URL}user`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+      'smart-chat-token-header-key': `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({
+      mobileNumber: mobileNumber,
+    }),
+  });
+  return response;
 };
 
-export const removeProfilePic = async(profile: string, mobileNumber: string, accessToken: string) => {
-    const response = await fetch(`${BASE_URL}user/profile`, {
-        method: 'DELETE',
-        headers: {
-            'Content-Type': 'application/json',
-            'smart-chat-token-header-key': `Bearer ${accessToken}`,
-        },
-        body: JSON.stringify({
-            profilePicture: profile,
-            mobileNumber: mobileNumber,
-        }),
-    });
-    return response;
+export const removeProfilePic = async (
+  profile: string,
+  mobileNumber: string,
+  accessToken: string,
+) => {
+  const response = await fetch(`${BASE_URL}user/profile`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+      'smart-chat-token-header-key': `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({
+      profilePicture: profile,
+      mobileNumber: mobileNumber,
+    }),
+  });
+  return response;
 };
 
-export const updateProfileDetails = async(property: string, value: string, mobileNumber: string, accessToken: string) => {
-    const response = await fetch(`${BASE_URL}user`, {
-        method: 'PATCH',
-        headers: {
-            'Content-Type': 'application/json',
-            'smart-chat-token-header-key': `Bearer ${accessToken}`,
-        },
-        body: JSON.stringify({
-            data: {
-                [property]: value,
-            },
-            mobileNumber: mobileNumber,
-        }),
-    });
-    return response;
+export const updateProfileDetails = async (
+  property: string,
+  value: string,
+  mobileNumber: string,
+  accessToken: string,
+) => {
+  const response = await fetch(`${BASE_URL}user`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      'smart-chat-token-header-key': `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({
+      data: {
+        [property]: value,
+      },
+      mobileNumber: mobileNumber,
+    }),
+  });
+  return response;
 };
 
-export const updateProfilePic = async(form: FormData, accessToken: string) => {
-    const response = await fetch(`${BASE_URL}user/profile`, {
-        method: 'PATCH',
-        headers: {
-            'Content-Type': 'multipart/form-data',
-            'smart-chat-token-header-key': `Bearer ${accessToken}`,
-        },
-        body: form,
-    });
-    return response;
+export const updatePassword = async (
+  mobileNumber: string,
+  oldPassword: string,
+  newPassword: string,
+  accessToken: string,
+) => {
+  const response = await fetch(`${BASE_URL}user/password`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      'smart-chat-token-header-key': `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({
+      mobileNumber,
+      oldPassword,
+      newPassword,
+    }),
+  });
+  return response;
 };
 
-export const logout = async(mobileNumber: string, accessToken: string) => {
-    const response = await fetch(`${BASE_URL}logout`, {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            'smart-chat-token-header-key': `Bearer ${accessToken}`,
-        },
-        body: JSON.stringify({mobileNumber: mobileNumber}),
-    });
-    return response;
+export const updateProfilePic = async (form: FormData, accessToken: string) => {
+  const response = await fetch(`${BASE_URL}user/profile`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'multipart/form-data',
+      'smart-chat-token-header-key': `Bearer ${accessToken}`,
+    },
+    body: form,
+  });
+  return response;
+};
+
+export const logout = async (mobileNumber: string, accessToken: string) => {
+  const response = await fetch(`${BASE_URL}logout`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'smart-chat-token-header-key': `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({mobileNumber: mobileNumber}),
+  });
+  return response;
 };

--- a/src/screens/Profile/Profile.tsx
+++ b/src/screens/Profile/Profile.tsx
@@ -1,16 +1,17 @@
+import { NavigationProp, useFocusEffect, useNavigation } from '@react-navigation/native';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Image, KeyboardAvoidingView, Platform, ScrollView, Text, TouchableOpacity, useWindowDimensions, View } from 'react-native';
 import EncryptedStorage from 'react-native-encrypted-storage';
 import { useDispatch, useSelector } from 'react-redux';
-import { NavigationProp, useFocusEffect, useNavigation } from '@react-navigation/native';
 import { AlertModal } from '../../components/AlertModal/AlertModal';
+import { ChangePasswordModal } from '../../components/ChangePasswordModal/ChangePasswordModal';
 import { CustomAlert } from '../../components/CustomAlert/CustomAlert';
 import LoadingIndicator from '../../components/Loading/Loading';
 import { ProfileInfoTile } from '../../components/ProfileInfoTile/ProfileInfoTile';
 import { ProfilePicturePickerModal } from '../../components/ProfilePicturePickerModal/ProfilePicturePickerModal';
+import { useRealmReset } from '../../contexts/RealmContext';
 import { useAppTheme } from '../../hooks/appTheme';
 import { useAlertModal } from '../../hooks/useAlertModal';
-import { useRealmReset } from '../../contexts/RealmContext';
 import { setUserProperty } from '../../redux/reducers/user.reducer';
 import { storeState } from '../../redux/store';
 import { RootStackParamList } from '../../types/Navigations';
@@ -43,6 +44,9 @@ export const Profile = (): React.JSX.Element => {
     null,
   );
   const [visibleProfilePicModal, setVisibleProfilePicModal] = useState(false);
+
+  const [showChangePasswordModal, setShowChangePasswordModal] = useState(false);
+
   const imageUploaded = useRef(false);
   const {resetRealm} = useRealmReset();
 
@@ -186,6 +190,7 @@ export const Profile = (): React.JSX.Element => {
     }
   };
 
+
   return (
     <KeyboardAvoidingView
       style={styles.container}
@@ -258,6 +263,7 @@ export const Profile = (): React.JSX.Element => {
             editField={editField}
             setEditField={setEditField}
             setLoading={setLoading}
+            onPress={() => setShowChangePasswordModal(true)}
           />
           <TouchableOpacity
             style={styles.box}
@@ -326,7 +332,13 @@ export const Profile = (): React.JSX.Element => {
           />
         </View>
       </ScrollView>
+      <ChangePasswordModal
+        visible={showChangePasswordModal}
+        onClose={() => setShowChangePasswordModal(false)}
+      />
+
       <CustomAlert visible={alertVisible} message={alertMessage} type={alertType} onClose={hideAlert} />
+
     </KeyboardAvoidingView>
   );
 };

--- a/src/screens/Registration/Registration.test.tsx
+++ b/src/screens/Registration/Registration.test.tsx
@@ -1,4 +1,4 @@
-import { useNavigation } from '@react-navigation/native';
+import {useNavigation} from '@react-navigation/native';
 import {
   act,
   fireEvent,
@@ -6,12 +6,12 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react-native';
-import { Alert } from 'react-native';
+import {Alert} from 'react-native';
 import EncryptedStorage from 'react-native-encrypted-storage';
-import { Provider } from 'react-redux';
-import { store } from '../../redux/store';
-import { generateKeyPair, storeKeys } from '../../utils/keyPairs';
-import { decryptPrivateKey, encryptPrivateKey } from '../../utils/privateKey';
+import {Provider} from 'react-redux';
+import {store} from '../../redux/store';
+import {generateKeyPair, storeKeys} from '../../utils/keyPairs';
+import {decryptPrivateKey, encryptPrivateKey} from '../../utils/privateKey';
 import Registration from './Registration';
 import * as RegistrationHandler from './Registration.service';
 
@@ -129,8 +129,11 @@ describe('Registration Screen check', () => {
     fireEvent.changeText(getByPlaceholderText('First Name *'), 'Mamatha');
     fireEvent.changeText(getByPlaceholderText('Last Name *'), 'Niya;');
     fireEvent.changeText(getByLabelText('phone-input'), '+91 1234567890');
-    fireEvent.changeText(getByPlaceholderText('Password *'), 'pass123');
-    fireEvent.changeText(getByPlaceholderText('Confirm Password *'), '123');
+    fireEvent.changeText(getByPlaceholderText('Password *'), 'Anjaligogu18@');
+    fireEvent.changeText(
+      getByPlaceholderText('Confirm Password *'),
+      'Anjaligogu415#',
+    );
     await act(async () => {
       fireEvent.press(getByText('Register'));
     });
@@ -189,8 +192,11 @@ describe('Registration Screen check', () => {
     fireEvent.changeText(getByPlaceholderText('Last Name *'), 'Barlapati');
     fireEvent.changeText(getByPlaceholderText('Email'), 'anju@gmail.com');
     fireEvent.changeText(getByLabelText('phone-input'), '+91 1234567890');
-    fireEvent.changeText(getByPlaceholderText('Password *'), '1234');
-    fireEvent.changeText(getByPlaceholderText('Confirm Password *'), '1234');
+    fireEvent.changeText(getByPlaceholderText('Password *'), 'Anjaligogu18@');
+    fireEvent.changeText(
+      getByPlaceholderText('Confirm Password *'),
+      'Anjaligogu18@',
+    );
     await act(async () => {
       fireEvent.press(getByText('Register'));
     });
@@ -199,7 +205,12 @@ describe('Registration Screen check', () => {
   it('Should give an alert on successful registration with message', async () => {
     const response = {
       ok: true,
-      json: async () => ({user: {}, userId: 'anjani123', access_token: 'access_token', refresh_token: 'refresh_token'}),
+      json: async () => ({
+        user: {},
+        userId: 'anjani123',
+        access_token: 'access_token',
+        refresh_token: 'refresh_token',
+      }),
     };
     (generateKeyPair as jest.Mock).mockResolvedValue({
       publicKey: 'mockPublicKey',
@@ -212,18 +223,23 @@ describe('Registration Screen check', () => {
       nonce: 'mockNonce',
       privateKey: 'mockEncryptedPrivateKey',
     });
-    (decryptPrivateKey as jest.Mock).mockResolvedValue('mockDecryptedPrivateKey');
+    (decryptPrivateKey as jest.Mock).mockResolvedValue(
+      'mockDecryptedPrivateKey',
+    );
     mockRegister.mockResolvedValue(response);
     (EncryptedStorage.setItem as jest.Mock).mockReturnValue(() => {});
     const {getByLabelText, getByPlaceholderText, getByText} =
-    renderRegistrationScreen();
+      renderRegistrationScreen();
 
     fireEvent.changeText(getByPlaceholderText('First Name *'), 'Varun');
     fireEvent.changeText(getByPlaceholderText('Last Name *'), 'Kumar');
     fireEvent.changeText(getByPlaceholderText('Email'), 'varun@gmail.com');
     fireEvent.changeText(getByLabelText('phone-input'), '+91 12345 67890');
-    fireEvent.changeText(getByPlaceholderText('Password *'), '1234');
-    fireEvent.changeText(getByPlaceholderText('Confirm Password *'), '1234');
+    fireEvent.changeText(getByPlaceholderText('Password *'), 'Anjaligogu18@');
+    fireEvent.changeText(
+      getByPlaceholderText('Confirm Password *'),
+      'Anjaligogu18@',
+    );
 
     await act(async () => {
       fireEvent.press(getByText('Register'));
@@ -241,14 +257,17 @@ describe('Registration Screen check', () => {
     mockRegister.mockResolvedValue(response);
 
     const {getByLabelText, getByPlaceholderText, getByText} =
-    renderRegistrationScreen();
+      renderRegistrationScreen();
 
     fireEvent.changeText(getByPlaceholderText('First Name *'), 'Varun');
     fireEvent.changeText(getByPlaceholderText('Last Name *'), 'Kumar');
     fireEvent.changeText(getByPlaceholderText('Email'), 'varun@gmail.com');
     fireEvent.changeText(getByLabelText('phone-input'), '+91 1234567890');
-    fireEvent.changeText(getByPlaceholderText('Password *'), '1234');
-    fireEvent.changeText(getByPlaceholderText('Confirm Password *'), '1234');
+    fireEvent.changeText(getByPlaceholderText('Password *'), 'Anjaligogu18@');
+    fireEvent.changeText(
+      getByPlaceholderText('Confirm Password *'),
+      'Anjaligogu18@',
+    );
     await act(async () => {
       fireEvent.press(getByText('Register'));
     });
@@ -261,13 +280,16 @@ describe('Registration Screen check', () => {
     mockRegister.mockRejectedValue(new Error('Internal server error'));
 
     const {getByLabelText, getByPlaceholderText, getByText} =
-    renderRegistrationScreen();
+      renderRegistrationScreen();
     fireEvent.changeText(getByPlaceholderText('First Name *'), 'Varun');
     fireEvent.changeText(getByPlaceholderText('Last Name *'), 'Kumar');
     fireEvent.changeText(getByPlaceholderText('Email'), 'varun@gmail.com');
     fireEvent.changeText(getByLabelText('phone-input'), '+91 1234567890');
-    fireEvent.changeText(getByPlaceholderText('Password *'), '1234');
-    fireEvent.changeText(getByPlaceholderText('Confirm Password *'), '1234');
+    fireEvent.changeText(getByPlaceholderText('Password *'), 'Anjaligogu18@');
+    fireEvent.changeText(
+      getByPlaceholderText('Confirm Password *'),
+      'Anjaligogu18@',
+    );
     await act(async () => {
       fireEvent.press(getByText('Register'));
     });
@@ -311,7 +333,9 @@ describe('Registration Screen check', () => {
       nonce: 'mockNonce',
       privateKey: 'mockEncryptedPrivateKey',
     });
-    (decryptPrivateKey as jest.Mock).mockResolvedValue('mockDecryptedPrivateKey');
+    (decryptPrivateKey as jest.Mock).mockResolvedValue(
+      'mockDecryptedPrivateKey',
+    );
 
     (mockRegister as jest.Mock).mockResolvedValue(response);
 
@@ -322,8 +346,11 @@ describe('Registration Screen check', () => {
     fireEvent.changeText(getByPlaceholderText('Last Name *'), 'Kumar');
     fireEvent.changeText(getByPlaceholderText('Email'), 'varun@gmail.com');
     fireEvent.changeText(getByLabelText('phone-input'), '+91 1234567890');
-    fireEvent.changeText(getByPlaceholderText('Password *'), '1234');
-    fireEvent.changeText(getByPlaceholderText('Confirm Password *'), '1234');
+    fireEvent.changeText(getByPlaceholderText('Password *'), 'Anjaligogu18@');
+    fireEvent.changeText(
+      getByPlaceholderText('Confirm Password *'),
+      'Anjaligogu18@',
+    );
 
     await act(async () => {
       fireEvent.press(getByText('Register'));
@@ -335,8 +362,12 @@ describe('Registration Screen check', () => {
       expect(storeKeys).toHaveBeenCalledWith(
         '1234567890',
         'mockPublicKey',
-        { salt: 'mockSalt', nonce: 'mockNonce', privateKey: 'mockEncryptedPrivateKey'},
-        'access_token'
+        {
+          salt: 'mockSalt',
+          nonce: 'mockNonce',
+          privateKey: 'mockEncryptedPrivateKey',
+        },
+        'access_token',
       );
 
       expect(EncryptedStorage.setItem).toHaveBeenCalledWith(

--- a/src/screens/Registration/Registration.test.tsx
+++ b/src/screens/Registration/Registration.test.tsx
@@ -123,7 +123,28 @@ describe('Registration Screen check', () => {
       expect(queryByText('Password is required')).toBeTruthy();
     });
   });
-  it('shows error when passwords do not match', async () => {
+  it('Should show validation when password when it doesn`t meet the require conditions ', async () => {
+    const {getByLabelText, getByPlaceholderText, getByText, queryByText} =
+      renderRegistrationScreen();
+
+    fireEvent.changeText(getByPlaceholderText('First Name *'), 'Anjali');
+    fireEvent.changeText(getByPlaceholderText('Last Name *'), 'Gogu');
+    fireEvent.changeText(getByPlaceholderText('Email'), 'anju415@.com');
+    fireEvent.changeText(getByLabelText('phone-input'), '+91 7702153247');
+    fireEvent.changeText(getByPlaceholderText('Password *'), 'anjali');
+
+    await act(async () => {
+      fireEvent.press(getByText('Register'));
+    });
+    await waitFor(() => {
+      expect(
+        queryByText(
+          'Password must be at least 8 characters long and include 1 uppercase, 1 lowercase, 1 number, and 1 special character',
+        ),
+      ).toBeTruthy();
+    });
+  });
+  it(' Should show error when passwords do not match', async () => {
     const {getByLabelText, getByPlaceholderText, getByText, queryByText} =
       renderRegistrationScreen();
     fireEvent.changeText(getByPlaceholderText('First Name *'), 'Mamatha');

--- a/src/screens/Registration/Registration.tsx
+++ b/src/screens/Registration/Registration.tsx
@@ -68,6 +68,9 @@ const Registration = () => {
   });
 
   const handleChange = (field: string, value: string) => {
+    if(field === 'email') {
+      value = value.trim().toLowerCase();
+    }
     setUser(prevValues => ({
       ...prevValues,
       [field]: value,

--- a/src/utils/themes.ts
+++ b/src/utils/themes.ts
@@ -1,3 +1,4 @@
+
 export const LightTheme = {
   primaryBackground: '#ffffff',
   secondaryBackground: '#B2D8D8',
@@ -21,6 +22,10 @@ export const LightTheme = {
   receiverMessageBox:'lightgray',
   timestamp : 'rgb(98, 98, 98)',
   alertButtonBackground: 'rgb(215, 41, 41)',
+   changePasswordModalBackground:'white',
+   changePasswordModalTitleColor: 'black',
+   changePasswordModalPlaceholderColor: 'rgb(176, 169, 169)',
+   ChangePasswordModalInputColor:'black',
   images: {
     camera: require('../../assets/icons/camera-icon.png'),
     gallery: require('../../assets/icons/gallery-icon.png'),
@@ -66,6 +71,10 @@ export const DarkTheme = {
   receiverMessageBox: 'gray',
   timestamp :'white',
   alertButtonBackground: 'rgba(231, 44, 44, 0.84)',
+  changePasswordModalBackground: 'rgb(31, 42, 49)',
+  changePasswordModalTitleColor: 'white',
+  changePasswordModalPlaceholderColor: 'rgb(126, 122, 122)',
+  ChangePasswordModalInputColor:'white',
   images: {
     camera: require('../../assets/icons/camera-icon-dark-theme.png'),
     gallery: require('../../assets/icons/gallery-icon-dark-theme.png'),


### PR DESCRIPTION
### 📌 What does this PR do ?

 This PR implements adding a changePasswordModal in the profile screen, when user tries to update their password.
- Added a password regex in `Registration screen`, which accepts a capital letter, a small letter, a number and at least one special character.
- Added `changePasswordModal`, which opens when user clicks change password in Profile screen.
- This modal takes, `oldPassword`, `newPassword` and `confirmPassword`, validates them and then sent to backend.
- A updatePassword service is written which makes a fetch call to the backend to update password.
- Responses from the backend are shown in the UI using `customAlerts`.
- Called the `changePasswordModal` in profile screen.
- updated styles to adapt for the both themes, dark and light.

#### ✅ Testing :

- Unit tested using `jest`, used mocking wherever required, everything is working as expected.

####  UI :

<img width="337" alt="Screenshot 2025-06-16 at 6 35 22 PM" src="https://github.com/user-attachments/assets/51bbc692-7881-403b-9766-9bb41e50e04d" />

<img width="345" alt="Screenshot 2025-06-16 at 6 36 28 PM" src="https://github.com/user-attachments/assets/8e794c5e-8f55-42fd-89da-bbb5289c994c" />

<img width="337" alt="Screenshot 2025-06-16 at 6 35 52 PM" src="https://github.com/user-attachments/assets/93c347fc-9eb9-4e6e-be12-d15aec1b5c24" />

