### PR TITLE
Fix SMS sending for Android API 34+

### DIFF
--- a/src/utils/sendSmsInvite.test.ts
+++ b/src/utils/sendSmsInvite.test.ts
@@ -40,6 +40,22 @@ describe('send SMS', () => {
       const result = await requestSmsPermission();
       expect(result).toBe(false);
     });
+     it('Should return false for Android API 34+', async () => {
+      Platform.OS = 'android';
+      Platform.Version = '34';
+
+      const result = await requestSmsPermission();
+      expect(result).toBe(false);
+      expect(Permissions.requestPermission).not.toHaveBeenCalled();
+    });
+     it('Should return false for Android API 35', async () => {
+      Platform.OS = 'android';
+      Platform.Version = '35';
+
+      const result = await requestSmsPermission();
+      expect(result).toBe(false);
+      expect(Permissions.requestPermission).not.toHaveBeenCalled();
+    });
   });
 
   describe('sendSmsInvite functionality', () => {

--- a/src/utils/sendSmsInvite.test.ts
+++ b/src/utils/sendSmsInvite.test.ts
@@ -140,5 +140,17 @@ describe('send SMS', () => {
       );
       expect(Linking.openURL).not.toHaveBeenCalled();
     });
+    it('Should uses Linking.openURL for Android API 34+', async () => {
+      Platform.OS = 'android';
+      Platform.Version = '34';
+
+      await sendSmsInvite(mobileNumber);
+
+      expect(Linking.openURL).toHaveBeenCalledWith(
+        expect.stringContaining('sms:9832145610?body='),
+      );
+      expect(Permissions.requestPermission).not.toHaveBeenCalled();
+      expect(SendSMS.send).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/utils/sendSmsInvite.test.ts
+++ b/src/utils/sendSmsInvite.test.ts
@@ -185,7 +185,7 @@ describe('send SMS', () => {
       expect(SendSMS.send).not.toHaveBeenCalled();
       expect(Linking.openURL).not.toHaveBeenCalled();
     });
-      it('Should handle SendSMS error', async () => {
+    it('Should handle SendSMS error', async () => {
       Platform.OS = 'android';
       Platform.Version = '33';
 
@@ -203,6 +203,19 @@ describe('send SMS', () => {
       expect(consoleSpy).toHaveBeenCalledWith('Failed to send SMS');
 
       consoleSpy.mockRestore();
+    });
+    it('Should use correct URL format for iOS', async () => {
+      Platform.OS = 'ios';
+
+      await sendSmsInvite(mobileNumber);
+
+      const expectedMessage =
+        "Let's chat on SmartChat! It's a fast, simple, and secure app we can use to message each other for free.";
+      const expectedUrl = `sms:${mobileNumber}&body=${encodeURIComponent(
+        expectedMessage,
+      )}`;
+
+      expect(Linking.openURL).toHaveBeenCalledWith(expectedUrl);
     });
   });
 });

--- a/src/utils/sendSmsInvite.test.ts
+++ b/src/utils/sendSmsInvite.test.ts
@@ -40,7 +40,7 @@ describe('send SMS', () => {
       const result = await requestSmsPermission();
       expect(result).toBe(false);
     });
-     it('Should return false for Android API 34+', async () => {
+    it('Should return false for Android API 34+', async () => {
       Platform.OS = 'android';
       Platform.Version = '34';
 
@@ -48,7 +48,7 @@ describe('send SMS', () => {
       expect(result).toBe(false);
       expect(Permissions.requestPermission).not.toHaveBeenCalled();
     });
-     it('Should return false for Android API 35', async () => {
+    it('Should return false for Android API 35', async () => {
       Platform.OS = 'android';
       Platform.Version = '35';
 
@@ -119,6 +119,26 @@ describe('send SMS', () => {
       expect(Linking.openURL).toHaveBeenCalledWith(
         expect.stringContaining('sms:'),
       );
+    });
+    it('Should use SendSMS.send on android API<34', async () => {
+      Platform.OS = 'android';
+      Platform.Version = '33';
+
+      (Permissions.requestPermission as jest.Mock).mockResolvedValue(true);
+      (SendSMS.send as jest.Mock).mockImplementation((_config, callback) => {
+        callback(true, false, null);
+      });
+
+      await sendSmsInvite(mobileNumber);
+
+      expect(SendSMS.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          body: expect.stringContaining("Let's chat on SmartChat!"),
+          recipients: [mobileNumber],
+        }),
+        expect.any(Function),
+      );
+      expect(Linking.openURL).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/utils/sendSmsInvite.test.ts
+++ b/src/utils/sendSmsInvite.test.ts
@@ -7,7 +7,7 @@ import {Platform, Linking} from 'react-native';
 
 jest.mock('react-native', () => ({
   Alert: {alert: jest.fn()},
-  Platform: {OS: 'android'},
+  Platform: {OS: 'android', Version: '33'},
   Linking: {openURL: jest.fn(() => Promise.resolve())},
 }));
 

--- a/src/utils/sendSmsInvite.test.ts
+++ b/src/utils/sendSmsInvite.test.ts
@@ -164,5 +164,19 @@ describe('send SMS', () => {
       expect(Permissions.requestPermission).not.toHaveBeenCalled();
       expect(SendSMS.send).not.toHaveBeenCalled();
     });
+     it('Should handle Linking.openURL error for Android API 34+', async () => {
+      Platform.OS = 'android';
+      Platform.Version = '34';
+
+      const mockError = new Error('SMS error');
+      (Linking.openURL as jest.Mock).mockRejectedValue(mockError);
+
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      await sendSmsInvite(mobileNumber);
+
+      expect(consoleSpy).toHaveBeenCalledWith('SMS error:', mockError);
+      consoleSpy.mockRestore();
+    });
   });
 });

--- a/src/utils/sendSmsInvite.test.ts
+++ b/src/utils/sendSmsInvite.test.ts
@@ -1,9 +1,7 @@
-import {Alert} from 'react-native';
-import * as Permissions from '../permissions/permissions';
+import { Alert, Linking, Platform } from 'react-native';
 import SendSMS from 'react-native-sms';
-import {requestSmsPermission} from './sendSmsInvite';
-import {sendSmsInvite} from './sendSmsInvite';
-import {Platform, Linking} from 'react-native';
+import * as Permissions from '../permissions/permissions';
+import { requestSmsPermission, sendSmsInvite } from './sendSmsInvite';
 
 jest.mock('react-native', () => ({
   Alert: {alert: jest.fn()},

--- a/src/utils/sendSmsInvite.test.ts
+++ b/src/utils/sendSmsInvite.test.ts
@@ -3,6 +3,7 @@ import * as Permissions from '../permissions/permissions';
 import SendSMS from 'react-native-sms';
 import {requestSmsPermission} from './sendSmsInvite';
 import {sendSmsInvite} from './sendSmsInvite';
+import {Platform, Linking} from 'react-native';
 
 jest.mock('react-native', () => ({
   Alert: {alert: jest.fn()},
@@ -91,7 +92,6 @@ describe('send SMS', () => {
       logSpy.mockRestore();
     });
     it('uses Linking.openURL on iOS', async () => {
-      const {Platform, Linking} = require('react-native');
       Platform.OS = 'ios';
 
       (Permissions.requestPermission as jest.Mock).mockResolvedValue(true);

--- a/src/utils/sendSmsInvite.test.ts
+++ b/src/utils/sendSmsInvite.test.ts
@@ -152,5 +152,17 @@ describe('send SMS', () => {
       expect(Permissions.requestPermission).not.toHaveBeenCalled();
       expect(SendSMS.send).not.toHaveBeenCalled();
     });
+      it('Should uses Linking.openURL for Android API 35', async () => {
+      Platform.OS = 'android';
+      Platform.Version = '35';
+
+      await sendSmsInvite(mobileNumber);
+
+      expect(Linking.openURL).toHaveBeenCalledWith(
+        expect.stringContaining('sms:9832145610?body='),
+      );
+      expect(Permissions.requestPermission).not.toHaveBeenCalled();
+      expect(SendSMS.send).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/utils/sendSmsInvite.test.ts
+++ b/src/utils/sendSmsInvite.test.ts
@@ -24,6 +24,8 @@ const mobileNumber = '9832145610';
 describe('send SMS', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    Platform.OS = 'android';
+    Platform.Version = '33';
   });
 
   describe('requestSmsPermission', () => {

--- a/src/utils/sendSmsInvite.test.ts
+++ b/src/utils/sendSmsInvite.test.ts
@@ -1,7 +1,7 @@
-import { Alert, Linking, Platform } from 'react-native';
+import {Alert, Linking, Platform} from 'react-native';
 import SendSMS from 'react-native-sms';
 import * as Permissions from '../permissions/permissions';
-import { requestSmsPermission, sendSmsInvite } from './sendSmsInvite';
+import {requestSmsPermission, sendSmsInvite} from './sendSmsInvite';
 
 jest.mock('react-native', () => ({
   Alert: {alert: jest.fn()},
@@ -150,7 +150,7 @@ describe('send SMS', () => {
       expect(Permissions.requestPermission).not.toHaveBeenCalled();
       expect(SendSMS.send).not.toHaveBeenCalled();
     });
-      it('Should uses Linking.openURL for Android API 35', async () => {
+    it('Should uses Linking.openURL for Android API 35', async () => {
       Platform.OS = 'android';
       Platform.Version = '35';
 
@@ -162,7 +162,7 @@ describe('send SMS', () => {
       expect(Permissions.requestPermission).not.toHaveBeenCalled();
       expect(SendSMS.send).not.toHaveBeenCalled();
     });
-     it('Should handle Linking.openURL error for Android API 34+', async () => {
+    it('Should handle Linking.openURL error for Android API 34+', async () => {
       Platform.OS = 'android';
       Platform.Version = '34';
 
@@ -175,6 +175,15 @@ describe('send SMS', () => {
 
       expect(consoleSpy).toHaveBeenCalledWith('SMS error:', mockError);
       consoleSpy.mockRestore();
+    });
+
+    it('should do nothing when platform is not iOS or Android', async () => {
+      Platform.OS = 'web';
+      await sendSmsInvite(mobileNumber);
+
+      expect(Permissions.requestPermission).not.toHaveBeenCalled();
+      expect(SendSMS.send).not.toHaveBeenCalled();
+      expect(Linking.openURL).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/utils/sendSmsInvite.test.ts
+++ b/src/utils/sendSmsInvite.test.ts
@@ -177,13 +177,32 @@ describe('send SMS', () => {
       consoleSpy.mockRestore();
     });
 
-    it('should do nothing when platform is not iOS or Android', async () => {
+    it('Should do nothing when platform is not iOS or Android', async () => {
       Platform.OS = 'web';
       await sendSmsInvite(mobileNumber);
 
       expect(Permissions.requestPermission).not.toHaveBeenCalled();
       expect(SendSMS.send).not.toHaveBeenCalled();
       expect(Linking.openURL).not.toHaveBeenCalled();
+    });
+      it('Should handle SendSMS error', async () => {
+      Platform.OS = 'android';
+      Platform.Version = '33';
+
+      (Permissions.requestPermission as jest.Mock).mockResolvedValue(true);
+
+      const errorObj = new Error('SMS failed');
+      (SendSMS.send as jest.Mock).mockImplementation((config, callback) => {
+        callback(false, false, errorObj);
+      });
+
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+      await sendSmsInvite(mobileNumber);
+
+      expect(consoleSpy).toHaveBeenCalledWith('Failed to send SMS');
+
+      consoleSpy.mockRestore();
     });
   });
 });

--- a/src/utils/sendSmsInvite.ts
+++ b/src/utils/sendSmsInvite.ts
@@ -16,11 +16,6 @@ export const requestSmsPermission = async () => {
 export const sendSmsInvite = async (mobileNumber: string) => {
   const inviteMessage =
     "Let's chat on SmartChat! It's a fast, simple, and secure app we can use to message each other for free.";
-  // const granted = await requestSmsPermission();
-  // if (!granted) {
-  //     Alert.alert('Permission denied', 'SMS permission is required to send invites.');
-  //     return;
-  // }
   if (Platform.OS === 'ios') {
     const url = `sms:${mobileNumber}&body=${encodeURIComponent(inviteMessage)}`;
     Linking.openURL(url).catch(err => console.error('SMS error:', err));

--- a/src/utils/sendSmsInvite.ts
+++ b/src/utils/sendSmsInvite.ts
@@ -1,6 +1,6 @@
-import { Alert, Linking, Platform } from 'react-native';
+import {Alert, Linking, Platform} from 'react-native';
 import SendSMS from 'react-native-sms';
-import { requestPermission } from '../permissions/permissions';
+import {requestPermission} from '../permissions/permissions';
 
 export const requestSmsPermission = async () => {
   if (Platform.OS === 'android' && Number(Platform.Version) >= 34) {
@@ -45,12 +45,12 @@ export const sendSmsInvite = async (mobileNumber: string) => {
           successTypes: ['sent', 'queued'] as any,
           allowAndroidSendWithoutReadPermission: true,
         },
-        (completed, cancelled, error) => {
+        (completed, cancelled) => {
           if (completed) {
             console.log('SMS Sent Successfully');
           } else if (cancelled) {
             console.log('SMS Sending Cancelled');
-          } else if (error) {
+          } else {
             console.log('Failed to send SMS');
           }
         },

--- a/src/utils/sendSmsInvite.ts
+++ b/src/utils/sendSmsInvite.ts
@@ -1,40 +1,65 @@
-import { Alert, Linking, Platform } from 'react-native';
-import { requestPermission } from '../permissions/permissions';
+import {Alert, Linking, Platform} from 'react-native';
+import {requestPermission} from '../permissions/permissions';
 import SendSMS from 'react-native-sms';
 
 export const requestSmsPermission = async () => {
-    const isPermissionGranted = await requestPermission('send-sms');
-    if (!isPermissionGranted) {
-        return false;
-    }
-    return true;
+  if (Platform.OS === 'android' && Number(Platform.Version) >= 34) {
+    return false;
+  }
+  const isPermissionGranted = await requestPermission('send-sms');
+  if (!isPermissionGranted) {
+    return false;
+  }
+  return true;
 };
 
 export const sendSmsInvite = async (mobileNumber: string) => {
-    const inviteMessage = 'Let\'s chat on SmartChat! It\'s a fast, simple, and secure app we can use to message each other for free.';
-    const granted = await requestSmsPermission();
-    if (!granted) {
-        Alert.alert('Permission denied', 'SMS permission is required to send invites.');
-        return;
-    }
-    if(Platform.OS === 'ios'){
-         const url = `sms:${mobileNumber}&body=${encodeURIComponent(inviteMessage)}`;
-         Linking.openURL(url).catch(err => console.error('SMS error:', err));
-         return;
-    }
-    SendSMS.send({
-        body: inviteMessage,
-        recipients: [mobileNumber],
-        successTypes: ['sent', 'queued'] as any,
-        allowAndroidSendWithoutReadPermission: true,
-    }, (completed, cancelled, error) => {
-        if (completed) {
-            console.log('SMS Sent Successfully');
-        } else if (cancelled) {
-            console.log('SMS Sending Cancelled');
-        } else if (error) {
-            console.log('Failed to send SMS');
-        }
-    });
+  const inviteMessage =
+    "Let's chat on SmartChat! It's a fast, simple, and secure app we can use to message each other for free.";
+  // const granted = await requestSmsPermission();
+  // if (!granted) {
+  //     Alert.alert('Permission denied', 'SMS permission is required to send invites.');
+  //     return;
+  // }
+  if (Platform.OS === 'ios') {
+    const url = `sms:${mobileNumber}&body=${encodeURIComponent(inviteMessage)}`;
+    Linking.openURL(url).catch(err => console.error('SMS error:', err));
     return;
+  }
+  if (Platform.OS === 'android') {
+    if (Number(Platform.Version) >= 34) {
+      const url = `sms:${mobileNumber}?body=${encodeURIComponent(
+        inviteMessage,
+      )}`;
+      Linking.openURL(url).catch(err => console.error('SMS error:', err));
+      return;
+    } else {
+      const granted = await requestSmsPermission();
+      if (!granted) {
+        Alert.alert(
+          'Permission denied',
+          'SMS permission is required to send invites.',
+        );
+        return;
+      }
+
+      SendSMS.send(
+        {
+          body: inviteMessage,
+          recipients: [mobileNumber],
+          successTypes: ['sent', 'queued'] as any,
+          allowAndroidSendWithoutReadPermission: true,
+        },
+        (completed, cancelled, error) => {
+          if (completed) {
+            console.log('SMS Sent Successfully');
+          } else if (cancelled) {
+            console.log('SMS Sending Cancelled');
+          } else if (error) {
+            console.log('Failed to send SMS');
+          }
+        },
+      );
+    }
+  }
 };

--- a/src/utils/sendSmsInvite.ts
+++ b/src/utils/sendSmsInvite.ts
@@ -1,6 +1,6 @@
-import {Alert, Linking, Platform} from 'react-native';
-import {requestPermission} from '../permissions/permissions';
+import { Alert, Linking, Platform } from 'react-native';
 import SendSMS from 'react-native-sms';
+import { requestPermission } from '../permissions/permissions';
 
 export const requestSmsPermission = async () => {
   if (Platform.OS === 'android' && Number(Platform.Version) >= 34) {


### PR DESCRIPTION
## What does this PR do:
* Fixed SMS permission check to work properly on Android 14+.
* Changed Android 14+ to open default SMS app instead of sending directly

✅ Testing: 
* Test cases working as expected.

Thank you!