### PR TITLE
Integration of OTP Verification feature with login when user is already logged in another device.

### DIFF
--- a/src/screens/Login/Login.test.tsx
+++ b/src/screens/Login/Login.test.tsx
@@ -97,6 +97,7 @@ jest.mock('../../utils/fcmService', () => ({
 describe('Login Screen check', () => {
   const mockReplace = jest.fn();
   const mockReset = jest.fn();
+  const mockNavigate = jest.fn();
 
   beforeEach(() => {
     jest.resetAllMocks();
@@ -104,6 +105,7 @@ describe('Login Screen check', () => {
     (useNavigation as jest.Mock).mockReturnValue({
       replace: mockReplace,
       reset: mockReset,
+      navigate: mockNavigate,
     });
     jest.spyOn(Alert, 'alert').mockImplementation(() => {});
   });
@@ -262,6 +264,32 @@ describe('Login Screen check', () => {
         routes: [{name: 'Tabs'}],
       });
     });
+  });
+
+
+  it('Should navigate to OTP verification screen if user is already logged in to another device', async () => {
+    const response = {
+      status: 206,
+      json: ()=>({data:{email:'anjanibarlapati@gmail.com'}}),
+    };
+
+    (LoginService.login as jest.Mock).mockResolvedValue(response);
+
+    const {getByLabelText, getByPlaceholderText, getByText} =
+      renderLoginScreen();
+
+    fireEvent.changeText(getByLabelText('phone-input'), '+91 1234567890');
+    fireEvent.changeText(getByPlaceholderText('Password'), 'Anjani@123');
+
+    await act(async () => {
+      fireEvent.press(getByText('Login'));
+    });
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith(
+          'OTPVerificationScreen', {'email': 'anjanibarlapati@gmail.com', 'from': 'login', 'mobileNumber': '+91 1234 567 890'}
+      );
+    });
+
   });
   it('Should display alert message if fetching chats fails', async () => {
     const response = {

--- a/src/screens/Login/Login.tsx
+++ b/src/screens/Login/Login.tsx
@@ -118,6 +118,11 @@ const LoginScreen = () => {
       setLoading(true);
       const response = await login(credentials);
       const result = await response.json();
+      if(response.status === 206){
+        clearFields();
+        navigation.navigate('OTPVerificationScreen', {mobileNumber: credentials.mobileNumber, email: result.data.email, from: 'login'});
+        return;
+      }
       if (response.ok) {
         clearFields();
         const encryptedPrivateKey = result.user.privateKey;

--- a/src/screens/OTPVerification/OtpVerification.service.ts
+++ b/src/screens/OTPVerification/OtpVerification.service.ts
@@ -1,3 +1,4 @@
+import { getDeviceId } from 'react-native-device-info';
 import { BASE_URL } from '../../utils/constants';
 
 export const verifyOTP = async (otp: string, mobileNumber: string) => {
@@ -34,4 +35,17 @@ export const createUser = async (mobileNumber: string) => {
     return response;
 
 };
+
+export const verifyLogin = async (mobileNumber: string, otp: string) => {
+    const response = await fetch(`${BASE_URL}verifyLogin`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ mobileNumber, deviceId: getDeviceId(), otp }),
+    });
+    return response;
+
+};
+
 

--- a/src/screens/OTPVerification/OtpVerification.styles.ts
+++ b/src/screens/OTPVerification/OtpVerification.styles.ts
@@ -42,7 +42,9 @@ export const getStyles = (theme: Theme, width: number) =>
       textAlign: 'center',
       marginTop: 8,
     },
-
+    emailText: {
+      color: '#008080',
+    },
     OtpView: {
       marginVertical: 20,
       alignItems: 'center',
@@ -60,7 +62,7 @@ export const getStyles = (theme: Theme, width: number) =>
     },
     errorText: {
       color: 'red',
-      fontSize: 16,
+      fontSize: 14,
       marginTop: 12,
       fontFamily: 'Nunito-Regular',
       textAlign: 'center',

--- a/src/screens/OTPVerification/OtpVerification.test.tsx
+++ b/src/screens/OTPVerification/OtpVerification.test.tsx
@@ -7,6 +7,9 @@ import { generateKeyPair, storeKeys } from '../../utils/keyPairs';
 import { decryptPrivateKey, encryptPrivateKey } from '../../utils/privateKey';
 import { OtpVerification } from './OtpVerification';
 import * as OtpService from './OtpVerification.service';
+import * as LoginService from '../Login/Login.service';
+import { storeChats } from '../../realm-database/operations/storeChats';
+import { useRealm } from '../../contexts/RealmContext';
 
 jest.mock('../../hooks/appTheme', () => ({
   useAppTheme: () => ({
@@ -15,6 +18,44 @@ jest.mock('../../hooks/appTheme', () => ({
     textSecondary: '#666',
   }),
 }));
+
+jest.mock('../../utils/keyPairs', () => ({
+  generateKeyPair: jest.fn(),
+  storeKeys: jest.fn(),
+}));
+
+jest.mock('../Login/Login.service', () => ({
+  fetchChats: jest.fn(),
+  formatMessages: jest.fn(),
+}));
+
+jest.mock('../../utils/privateKey', () => ({
+  encryptPrivateKey: jest.fn(),
+  decryptPrivateKey: jest.fn(),
+}));
+
+jest.mock('realm', () => ({
+  BSON: {
+    ObjectId: jest.fn(() => 'mocked-object-id'),
+  },
+}));
+
+jest.mock('../../contexts/RealmContext', () => ({
+  useRealm: jest.fn(),
+}));
+
+jest.mock('../../realm-database/operations/storeChats', () => ({
+  storeChats: jest.fn(),
+}));
+
+jest.mock('../../utils/fcmService', () => ({
+  generateAndUploadFcmToken: jest.fn,
+}));
+
+const mockRealmInstance = {
+  write: jest.fn((fn) => fn()),
+  create: jest.fn(),
+};
 
 jest.mock('./OtpVerification.service');
 
@@ -92,13 +133,19 @@ const mockNavigation = {
   reset: jest.fn(),
 };
 
+let mockRouteParams = {
+  mobileNumber: '1234567890',
+  email: 'test@gmail.com',
+  from: 'registration',
+};
+
 jest.mock('@react-navigation/native', () => {
   const actualNav = jest.requireActual('@react-navigation/native');
   return {
     ...actualNav,
     useNavigation: () => mockNavigation,
     useRoute: () => ({
-      params: { mobileNumber: '1234567890', email: 'test@gmail.com' },
+      params: mockRouteParams,
     }),
   };
 });
@@ -114,6 +161,8 @@ const renderOtpVerificationScreen = () => {
 describe('OtpVerification screen tests', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (useRealm as jest.Mock).mockReturnValue(mockRealmInstance);
+
   });
 
   it('should render static elements', () => {
@@ -132,6 +181,72 @@ describe('OtpVerification screen tests', () => {
     await waitFor(() => {
       expect(getByText('Invalid OTP')).toBeTruthy();
     });
+  });
+
+  it('should countdown timer from 2:00 to 1:59', async () => {
+    jest.useFakeTimers();
+    const { getByText } = renderOtpVerificationScreen();
+    expect(getByText('2:00')).toBeTruthy();
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    await waitFor(() => {
+      expect(getByText('1:59')).toBeTruthy();
+    });
+    jest.useRealTimers();
+  });
+
+  it('should not allow submission when OTP is less than 6 digits', async () => {
+    const { getByText, getByLabelText } = renderOtpVerificationScreen();
+    fireEvent.changeText(getByLabelText('One-Time Password'), '1234');
+    const submitButton = getByText('Submit');
+    expect(submitButton.props.accessibilityState?.disabled).toBeFalsy();
+  });
+
+   it('should clear OTP field and hide loader after submission', async () => {
+    (OtpService.verifyOTP as jest.Mock).mockResolvedValue({ ok: true });
+    (OtpService.createUser as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        user: { mobileNumber: '1234567890', email: 'test@gmail.com' },
+        userId: 'user123',
+        access_token: 'accessToken',
+        refresh_token: 'refreshToken',
+      }),
+    });
+
+    const { getByText, getByLabelText, queryByLabelText } = renderOtpVerificationScreen();
+    fireEvent.changeText(getByLabelText('One-Time Password'), '123456');
+    fireEvent.press(getByText('Submit'));
+
+    await waitFor(() => {
+      expect(queryByLabelText('One-Time Password')).toBeTruthy();
+    });
+  });
+
+  it('should not allow resend OTP if timer is still running', async () => {
+    const { getByText } = renderOtpVerificationScreen();
+    const resendButton = getByText('Resend Code?');
+    fireEvent.press(resendButton);
+    expect(OtpService.generateOTPAndSendMail).not.toHaveBeenCalled();
+  });
+
+  it('should not resend OTP if already clicked once after timer ends', async () => {
+    jest.useFakeTimers();
+    const { getByText } = renderOtpVerificationScreen();
+
+    act(() => {
+      jest.advanceTimersByTime(120000);
+    });
+
+    fireEvent.press(getByText('Resend Code?'));
+    fireEvent.press(getByText('Resend Code?'));
+    await waitFor(() => {
+      expect(OtpService.generateOTPAndSendMail).toHaveBeenCalledTimes(1);
+    });
+    jest.useRealTimers();
   });
 
   it('should proceed to home screen on successful verification and user creation', async () => {
@@ -265,5 +380,130 @@ describe('OtpVerification screen tests', () => {
       expect(queryByText('Resend failed')).toBeTruthy();
     });
     jest.useRealTimers();
+  });
+
+
+    it('submits OTP and navigates to Tabs for login', async () => {
+    mockRouteParams.from = 'login';
+    const response = {
+      ok: true,
+      json: async () => ({
+        user: {
+          firstName: 'Varun',
+          lastName: 'Kumar',
+          email: 'varun@gmail.com',
+          mobileNumber: '1234567890',
+          privateKey: {salt: 'salt',nonce:'noce', privateKey: 'privateKey'},
+        },
+        userId:'anjani123',
+        access_token: 'access_token',
+        refresh_token: 'refresh_token',
+      }),
+    };
+    const mockChatsResponse = {
+      ok: true,
+      json: async () => ([]),
+    };
+    (decryptPrivateKey as jest.Mock).mockResolvedValue('mockDecryptedPrivateKey');
+
+    (OtpService.verifyLogin as jest.Mock).mockResolvedValue(response);
+    (LoginService.fetchChats as jest.Mock).mockResolvedValue(mockChatsResponse);
+    (LoginService.formatMessages as jest.Mock).mockResolvedValue({});
+    (storeChats as jest.Mock).mockReturnValue({});
+    (EncryptedStorage.setItem as jest.Mock).mockResolvedValue(null);
+
+
+    const { getByText, getByLabelText } = renderOtpVerificationScreen();
+    fireEvent.changeText(getByLabelText('One-Time Password'), '654321');
+    fireEvent.press(getByText('Submit'));
+
+    await waitFor(() => {
+      expect(mockNavigation.reset).toHaveBeenCalledWith({
+        index: 0,
+        routes: [{ name: 'Tabs' }],
+      });
+    });
+  });
+
+  it('shows error if login verification fails', async () => {
+    mockRouteParams.from = 'login';
+
+    (OtpService.verifyLogin as jest.Mock).mockResolvedValue({
+      ok: false,
+      json: async () => ({ message: 'Verification failed' }),
+    });
+
+    const { getByText, getByLabelText } = renderOtpVerificationScreen();
+    fireEvent.changeText(getByLabelText('One-Time Password'), '123456');
+    fireEvent.press(getByText('Submit'));
+
+    await waitFor(() => {
+      expect(getByText('Verification failed')).toBeTruthy();
+    });
+  });
+
+  it('handles thrown error in handleLoginSubmit and navigates to LoginScreen', async () => {
+    mockRouteParams.from = 'login';
+
+    (OtpService.verifyLogin as jest.Mock).mockRejectedValue(new Error('Login API failed'));
+
+    const { getByText, getByLabelText } = renderOtpVerificationScreen();
+    fireEvent.changeText(getByLabelText('One-Time Password'), '123456');
+    fireEvent.press(getByText('Submit'));
+
+    await waitFor(() => {
+      expect(getByText('Login API failed')).toBeTruthy();
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 3100));
+    });
+
+    expect(mockNavigation.replace).toHaveBeenCalledWith('LoginScreen');
+  });
+
+  it('shows error and navigates to LoginScreen if fetchChats fails', async () => {
+    mockRouteParams.from = 'login';
+
+    const response = {
+      ok: true,
+      json: async () => ({
+        user: {
+          email: 'abc@test.com',
+          mobileNumber: '1234567890',
+          privateKey: {
+            salt: 'salt',
+            nonce: 'nonce',
+            privateKey: 'encryptedKey',
+          },
+        },
+        userId: 'user123',
+        access_token: 'token',
+        refresh_token: 'refresh',
+      }),
+    };
+
+    const chatError = {
+      ok: false,
+      json: async () => ({ message: 'Unable to fetch chats' }),
+    };
+
+    (OtpService.verifyLogin as jest.Mock).mockResolvedValue(response);
+    (LoginService.fetchChats as jest.Mock).mockResolvedValue(chatError);
+    (decryptPrivateKey as jest.Mock).mockResolvedValue('decryptedKey');
+
+    const { getByText, getByLabelText } = renderOtpVerificationScreen();
+    fireEvent.changeText(getByLabelText('One-Time Password'), '654321');
+    fireEvent.press(getByText('Submit'));
+
+    await waitFor(() => {
+      expect(getByText('Unable to fetch chats')).toBeTruthy();
+    });
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 3100));
+    });
+
+    expect(mockNavigation.replace).toHaveBeenCalledWith('LoginScreen');
   });
 });

--- a/src/screens/Registration/Registration.test.tsx
+++ b/src/screens/Registration/Registration.test.tsx
@@ -269,7 +269,7 @@ describe('Registration Screen check', () => {
     expect(mockReplace).toHaveBeenCalledWith('LoginScreen');
   });
 
-  it('Should navigate to Home Screen on successful registration and store keys', async () => {
+  it('Should navigate to OTPVerification Screen if user details are verified', async () => {
     const response = {
       ok: true,
       json: async () => ({}),


### PR DESCRIPTION
## 📌 What does this PR do?
- This PR integrates OTP Verification with login feature.
- This PR modifies the login feature to navigate to  OTP verification screen if user is already logged in another device by sending OTP to user email.
- Updated OTP verification feature to allow user to verify OTP in two attempts. 
- Handled all the possible edge cases in OTP verification step. When user successfully verifies OTP, will be navigated to home screen.

### 🧪 Testing
- All the code added and updated in this screen were unit test using `jest` and `RNTL` and everything is working as expected with backend.

Thank you 😊!